### PR TITLE
fix ERROR on gasp table check due to a typo leading to a bad string formatting syntax crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.6.3 (2018-Nov-26)
+### Bug fixes
+  - **[com.google.fonts/check/062]:** fix a typo leading to a bad string formatting syntax crash. (issue #2183)
+
 ### Changes to existing checks
   - **[com.google.fonts/check/102]:** Check for consistency of copyright notice strings on both METADATA.pb and on name table entries. (issue #2210)
 

--- a/Lib/fontbakery/specifications/googlefonts.py
+++ b/Lib/fontbakery/specifications/googlefonts.py
@@ -1145,7 +1145,7 @@ def com_google_fonts_check_062(ttFont):
             value = ttFont["gasp"].gaspRange[0xFFFF]
             if value != 0x0F:
               failed = True
-              yield WARN, (f"gaspRange 0xFFFF value {value:%02X}"
+              yield WARN, (f"gaspRange 0xFFFF value 0x{value:02X}"
                             " should be set to 0x0F.")
         if not failed:
           yield PASS, ("'gasp' table is correctly set, with one "


### PR DESCRIPTION
Fixes com.google.fonts/check/062

This pull request addresses the problems described at issue #2183 
