### PR TITLE
Check-polymorphism: alternative implementations for a given check-ID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - Check statuses may now also be overriden via configuration file. See USAGE.md for examples. (PR #3469)
   - We now use the CheckTester helper class is all our code-tests. (PR #3453)
   - The `get_family_checks` method also takes into account usage of the `fonts` dependency, in addition to `ttFonts`.
+  - Check-polymorphism: alternative implementations for a given check-ID. This allows one to have multiple checks for the same font problem, but operating in different file formats such as: **(1)** font binaries (ttFont objects) **(2)** GlyphsApp sources **(3)** UFO fonts, etc. (issue #3436)
+  - This release includes a couple polymorphic checks for both **TTF binaries** and **Glyphs App sources**.
 
 ### Changes to existing checks
 #### On the Universal Profile
@@ -19,6 +21,8 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/repo/sample_image]:** The README.md file has a sample image to showcase the font family? (issue #2898)
   - **[com.google.fonts/check/metadata/can_render_samples]:** Ensure sample_text in METADATA.pb can be rendered in the font (issue #3419)
+  - **[com.google.fonts/check/name/family_and_style_max_length]:** Polymorphic implementation for Glyphs App source files. (issue #3436)
+  - **[com.google.fonts/check/font_copyright]:** Polymorphic implementation for Glyphs App source files. (issue #3436)
 
 ### Deprecated Checks
 #### Removed from the Universal Profile

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -106,11 +106,6 @@ NAME_TABLE_CHECKS = [
     'com.google.fonts/check/name/rfn'
 ]
 
-GLYPHSAPP_CHECKS = [
-    'com.google.fonts/check/glyphs_file/name/family_and_style_max_length',
-    'com.google.fonts/check/glyphs_file/font_copyright'
-]
-
 REPO_CHECKS = [
     'com.google.fonts/check/repo/dirname_matches_nameid_1',
     'com.google.fonts/check/repo/vf_has_static_fonts',
@@ -199,8 +194,7 @@ GOOGLEFONTS_PROFILE_CHECKS = \
     FAMILY_CHECKS + \
     NAME_TABLE_CHECKS + \
     REPO_CHECKS + \
-    FONT_FILE_CHECKS + \
-    GLYPHSAPP_CHECKS
+    FONT_FILE_CHECKS
 
 
 @check(
@@ -2320,8 +2314,10 @@ def com_google_fonts_check_metadata_valid_copyright(font_metadata):
                       f'But instead we have got:\n"{string}"')
 
 
+# Base-check for font binaries:
 @check(
     id = 'com.google.fonts/check/font_copyright',
+    conditions = ["ttFont"],
     proposal = 'https://github.com/googlefonts/fontbakery/pull/2383'
 )
 def com_google_fonts_check_font_copyright(ttFont):
@@ -2346,8 +2342,10 @@ def com_google_fonts_check_font_copyright(ttFont):
         yield PASS, "Name table copyright entries are good"
 
 
+# Polymorphism: Check Glyphs App source files:
 @check(
-    id = 'com.google.fonts/check/glyphs_file/font_copyright'
+    id = 'com.google.fonts/check/font_copyright',
+    conditions = ["glyphsFile"]
 )
 def com_google_fonts_check_glyphs_file_font_copyright(glyphsFile):
     """Copyright notices match canonical pattern in fonts"""
@@ -4248,7 +4246,7 @@ def com_google_fonts_check_kerning_for_non_ligated_sequences(ttFont, ligatures, 
             yield PASS, ("GPOS table provides kerning info for "
                          "all non-ligated sequences.")
 
-
+# Base-check for font binaries:
 @check(
     id = 'com.google.fonts/check/name/family_and_style_max_length',
     rationale = """
@@ -4259,6 +4257,7 @@ def com_google_fonts_check_kerning_for_non_ligated_sequences(ttFont, ligatures, 
         [1] https://glyphsapp.com/tutorials/multiple-masters-part-3-setting-up-instances
         [2] https://github.com/googlefonts/fontbakery/issues/2179
     """,
+    conditions = ["ttFont"],
     proposal = 'https://github.com/googlefonts/fontbakery/issues/1488',
     misc_metadata = {
         # Somebody with access to Windows should make some experiments
@@ -4297,8 +4296,10 @@ def com_google_fonts_check_name_family_and_style_max_length(ttFont):
         yield PASS, "All name entries are good."
 
 
+# Polymorphism: Check Glyphs App source files:
 @check(
-    id = 'com.google.fonts/check/glyphs_file/name/family_and_style_max_length',
+    id = 'com.google.fonts/check/name/family_and_style_max_length',
+    conditions = ["glyphsFile"]
 )
 def com_google_fonts_check_glyphs_file_name_family_and_style_max_length(glyphsFile):
     """Combined length of family and style must not exceed 27 characters."""
@@ -4331,6 +4332,7 @@ def com_google_fonts_check_glyphs_file_name_family_and_style_max_length(glyphsFi
 
         For instance, some designers like to include the full text of a font license in the "copyright notice" entry, but for the GFonts collection this entry should only mention year, author and other basic info in a manner enforced by com.google.fonts/check/font_copyright
     """,
+    conditions = ["ttFont"],
     proposal = 'legacy:check/057'
 )
 def com_google_fonts_check_name_line_breaks(ttFont):

--- a/tests/profiles/fontval_test.py
+++ b/tests/profiles/fontval_test.py
@@ -1,8 +1,9 @@
 import pytest
 import shutil
 
-from fontbakery.codetesting import (TEST_FILE,
-                                    assert_results_contain)
+from fontbakery.codetesting import (assert_results_contain,
+                                    CheckTester,
+                                    TEST_FILE)
 from fontbakery.checkrunner import ERROR
 from fontbakery.profiles import fontval as fontval_profile
 
@@ -10,9 +11,8 @@ from fontbakery.profiles import fontval as fontval_profile
   reason="FontValidator is not installed on your system")
 def test_check_fontvalidator():
     """ MS Font Validator checks """
-    # check = CheckTester(fontval_profile,
-    #                     "com.google.fonts/check/fontvalidator")
-    check = fontval_profile.com_google_fonts_check_fontvalidator
+    check = CheckTester(fontval_profile,
+                        "com.google.fonts/check/fontvalidator")
 
     font = TEST_FILE("mada/Mada-Regular.ttf")
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -368,6 +368,8 @@ def test_check_name_family_and_style_max_length():
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/name/family_and_style_max_length")
 
+    ################# Font binaries: #################
+
     # Our reference Cabin Regular is known to be good 
     ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
 
@@ -406,11 +408,7 @@ def test_check_name_family_and_style_max_length():
                            WARN, 'too-long',
                            'with a bad font...')
 
-
-def test_check_glyphs_file_name_family_and_style_max_length():
-    """ Combined length of family and style must not exceed 27 characters. """
-    check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/glyphs_file/name/family_and_style_max_length")
+    ################# Glyphs App sources: #################
 
     # Our reference Comfortaa.glyphs is known to be good
     glyphsFile = GLYPHSAPP_TEST_FILE("Comfortaa.glyphs")
@@ -1777,6 +1775,8 @@ def test_check_font_copyright():
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/font_copyright")
 
+    ################# Font binaries: #################
+
     # Our reference Cabin Regular is known to be bad
     # Since it provides an email instead of a git URL:
     ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
@@ -1796,10 +1796,7 @@ def test_check_font_copyright():
                 'with good strings...')
 
 
-def test_check_glyphs_file_font_copyright():
-    """Copyright notices match canonical pattern in fonts"""
-    check = CheckTester(googlefonts_profile,
-                        "com.google.fonts/check/glyphs_file/font_copyright")
+    ################# Glyphs App sources: #################
 
     glyphsFile = GLYPHSAPP_TEST_FILE("Comfortaa.glyphs")
     # note: the check does not actually verify that the project name is correct.


### PR DESCRIPTION
This allows one to have multiple checks for the same font problem, but operating in different file formats such as: **(1)** font binaries (ttFont objects) **(2)** GlyphsApp sources **(3)** UFO fonts, etc.

This commit includes a couple examples with checks for ttFonts and glyphs files.
(issue #3436)

**Note:** This PR is an improvement on code originally written by @simoncozens at https://github.com/simoncozens/fontbakery/tree/multiple-implementations-parking-lot (see also: https://github.com/googlefonts/fontbakery/issues/3436#issuecomment-911630988)