### PR TITLE
Temporarily disabled GlyphsApp source checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## 0.8.3 (2021-Oct-??)
+## 0.8.4 (2021-Nov-??)
+  - ...
+
+
+## 0.8.3 (2021-Oct-28)
 ### Noteworthy code-changes
   - This release drops Python 3.6 support (issue #3459)
   - Check statuses may now also be overriden via configuration file. See USAGE.md for examples. (PR #3469)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -106,9 +106,13 @@ NAME_TABLE_CHECKS = [
     'com.google.fonts/check/name/rfn'
 ]
 
+
+# The glyphs checks will be enabled once
+#  we implement check polymorphism
+# https://github.com/googlefonts/fontbakery/issues/3436
 GLYPHSAPP_CHECKS = [
-    'com.google.fonts/check/glyphs_file/name/family_and_style_max_length',
-    'com.google.fonts/check/glyphs_file/font_copyright'
+#DISABLED:    'com.google.fonts/check/glyphs_file/name/family_and_style_max_length',
+#DISABLED:    'com.google.fonts/check/glyphs_file/font_copyright'
 ]
 
 REPO_CHECKS = [
@@ -2346,6 +2350,7 @@ def com_google_fonts_check_font_copyright(ttFont):
         yield PASS, "Name table copyright entries are good"
 
 
+@disable
 @check(
     id = 'com.google.fonts/check/glyphs_file/font_copyright'
 )
@@ -4297,6 +4302,7 @@ def com_google_fonts_check_name_family_and_style_max_length(ttFont):
         yield PASS, "All name entries are good."
 
 
+@disable
 @check(
     id = 'com.google.fonts/check/glyphs_file/name/family_and_style_max_length',
 )

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -407,7 +407,7 @@ def test_check_name_family_and_style_max_length():
                            'with a bad font...')
 
 
-def test_check_glyphs_file_name_family_and_style_max_length():
+def DISABLED_test_check_glyphs_file_name_family_and_style_max_length():
     """ Combined length of family and style must not exceed 27 characters. """
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/glyphs_file/name/family_and_style_max_length")
@@ -1796,7 +1796,7 @@ def test_check_font_copyright():
                 'with good strings...')
 
 
-def test_check_glyphs_file_font_copyright():
+def DISABLE_test_check_glyphs_file_font_copyright():
     """Copyright notices match canonical pattern in fonts"""
     check = CheckTester(googlefonts_profile,
                         "com.google.fonts/check/glyphs_file/font_copyright")


### PR DESCRIPTION
The plan is to enable them once we get check-polymorphism support.
(issue #3436)