### PR TITLE
WARN if a font has a softhyphen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## 0.8.4 (2021-Nov-??)
-  - ...
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/contour_count]:** WARN if a font has a softhyphen. Also, if present, it should be non-spacing (and should have no contours). (issue #3486)
 
 
 ## 0.8.3 (2021-Oct-28)

--- a/Lib/fontbakery/glyphdata.py
+++ b/Lib/fontbakery/glyphdata.py
@@ -1110,10 +1110,11 @@ desired_glyph_data = \
         ]
     }, 
     {
+        # soft hyphen
         "name": "uni00AD", 
         "unicode": 173, 
         "contours": [
-            1
+            0
         ]
     }, 
     {

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3070,7 +3070,8 @@ def com_google_fonts_check_contour_count(ttFont):
     be the 'recommended' anchor counts for each glyph.
     """
     from fontbakery.glyphdata import desired_glyph_data as glyph_data
-    from fontbakery.utils import (get_font_glyph_data,
+    from fontbakery.utils import (bullet_list,
+                                  get_font_glyph_data,
                                   pretty_print_list)
 
     def in_PUA_range(codepoint):
@@ -3114,6 +3115,16 @@ def com_google_fonts_check_contour_count(ttFont):
         font_glyph_contours_by_glyphname = {f['name']: list(f['contours'])[0]
                                             for f in font_glyph_data}
 
+        if 0x00AD in font_glyph_contours_by_codepoint.keys():
+            yield WARN,\
+                  Message("softhyphen",
+                          "This font has a 'Soft Hyphen' character (codepoint 0x00AD)"
+                          " which is supposed to be zero-width and invisible, and is"
+                          " used to mark a hyphenation possibility within a word"
+                          " in the absence of or overriding dictionary hyphenation."
+                          " It is mostly an obsolete mechanism now, and the character"
+                          " is only included in fonts for legacy codepage coverage.")
+
         shared_glyphs_by_codepoint = set(desired_glyph_contours_by_codepoint) & \
                                      set(font_glyph_contours_by_codepoint)
         for glyph in sorted(shared_glyphs_by_codepoint):
@@ -3146,7 +3157,7 @@ def com_google_fonts_check_contour_count(ttFont):
                 f"Expected: {pretty_print_list(expected, shorten=None, glue='or')}"
                 for name, count, expected in bad_glyphs
             ]
-            bad_glyphs_name = '\n'.join(bad_glyphs_name)
+            bad_glyphs_name = bullet_list(bad_glyphs_name)
             yield WARN,\
                   Message("contour-count",
                           f"This check inspects the glyph outlines and detects the"
@@ -3164,7 +3175,8 @@ def com_google_fonts_check_contour_count(ttFont):
                           f"The following glyphs do not have the recommended"
                           f" number of contours:\n"
                           f"\n"
-                          f"{bad_glyphs_name}")
+                          f"{bad_glyphs_name}"
+                          f"\n")
         else:
             yield PASS, "All glyphs have the recommended amount of contours"
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2296,8 +2296,11 @@ def test_check_contour_count(montserrat_ttFonts):
     # TODO: FAIL, "lacks-cmap"
 
     for ttFont in montserrat_ttFonts:
-        assert_PASS(check(ttFont),
-                    'Montserrat which was used to assemble the glyph data...')
+        # Montserrat which was used to assemble the glyph data,
+        # so, it should be good, except for that softhyphen...
+        # TODO: how can we test PASS then?
+        assert_results_contain(check(ttFont),
+                               WARN, 'softhyphen')
 
     # Lets swap the glyf 'a' (2 contours) with glyf 'c' (1 contour)
     for ttFont in montserrat_ttFonts:


### PR DESCRIPTION
Also, if present, it should be non-spacing (and should have no contours).

**com.google.fonts/check/contour_count**
(issue #3486)