### PR TITLE
check/contour_count: do not expect ZWNJ and ZWJ glyphs to have zero contours.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/contour_count]:** WARN if a font has a softhyphen. Also, if present, it should be non-spacing (and should have no contours). (issue #3486)
+  - **[com.google.fonts/check/contour_count]:** Do not expect ZWNJ and ZWJ glyphs to have zero contours. (issue #3487)
 
 
 ## 0.8.3 (2021-Oct-28)

--- a/Lib/fontbakery/glyphdata.py
+++ b/Lib/fontbakery/glyphdata.py
@@ -84,13 +84,15 @@ desired_glyph_data = \
             0
         ]
     }, 
-    {
-        "name": "uni200C", 
-        "unicode": 8204, 
-        "contours": [
-            0
-        ]
-    }, 
+#    While ZWNJ and ZWJ display is suppressed in most text conditions, we follow Microsoft’s recommendation that visible glyphs be provided for these and other formatting characters, which can be displayed in text editing conditions
+#    https://github.com/googlefonts/fontbakery/issues/3487
+#    {
+#        "name": "uni200C", #ZWNJ: zero width non-joiner
+#        "unicode": 8204, 
+#        "contours": [
+#            0
+#        ]
+#    }, 
     {
         "name": "nonmarkingreturn", 
         "unicode": 13, 
@@ -4248,13 +4250,15 @@ desired_glyph_data = \
             2
         ]
     }, 
-    {
-        "name": "uni200D", 
-        "unicode": 8205, 
-        "contours": [
-            0
-        ]
-    }, 
+#    While ZWNJ and ZWJ display is suppressed in most text conditions, we follow Microsoft’s recommendation that visible glyphs be provided for these and other formatting characters, which can be displayed in text editing conditions
+#    https://github.com/googlefonts/fontbakery/issues/3487
+#    {
+#        "name": "uni200D", #ZWJ: zero width joiner
+#        "unicode": 8205, 
+#        "contours": [
+#            0
+#        ]
+#    }, 
     {
         "name": "uni0292", 
         "unicode": 658, 


### PR DESCRIPTION
(issue #3487)