### PR TITLE
check_profile: do not overwrite values_ dict with values_keys

### DIFF
--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -289,7 +289,7 @@ def main(profile=None, values=None):
     # these are keys for custom arguments required by the profile.
     if values_keys:
         for key in values_keys:
-            if hasattr(args, key):
+            if hasattr(args, key) and key not in values_:
                 values_[key] = getattr(args, key)
 
     if args.configfile:


### PR DESCRIPTION
I'm probably doing this incorrectly so please feel free to correct me.

I want to run fontbakery by simply calling the function `fontbakery.commands.check_profile.main`. This function has an argument called `values` which is used to populate the required arguments for the CheckRunner.

Upon executing the function with a populated values dictionary, the values get updated by another dictionary which comes from an ArgumentParser. The ArgumentParser dict will overwrite any existing values, even if the ArgumentParser values are empty e.g 

```
values={'fonts": ["myfonts.ttf"]}
args={"fonts": []}
--> values={"fonts": []}
```

This PR will only add keys and values from the ArgumentParser dictionary if they are not already included in the values dict.

cc @graphicore