### PR TITLE
New check: /check/colliding_accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Universal Profile
   - **[com.google.fonts/check/cjk_chws_feature]:** Ensure CJK fonts contain chws/vchw features. (issue #3363)
 
+#### Added to the Google Fonts Profile
+  - **[com.google.fonts/check/colliding_accents]:** Detect colliding accents at small point sizes. (issue #3506)
+
 ### Changes to existing checks
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/contour_count]:** Four fifths glyph can also be drawn with only 3 contours if the four is open-ended. (issue #3511)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ font-v==2.0.0
 lxml==4.6.4
 opentype-sanitizer==8.1.4.post3
 opentypespec==1.8.4
+pillow==8.4.0
 pip-api==0.0.23
 protobuf==3.19.1
 PyYAML==6.0

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'opentype-sanitizer>=7.1.9',  # 7.1.9 fixes caret value format = 3 bug
                                       # (see https://github.com/khaledhosny/ots/pull/182)
         'opentypespec',
+        'pillow',
         'pip-api',
         'protobuf>=3.7.0',  # 3.7.0 fixed a bug on parsing some METADATA.pb files
                             # (see https://github.com/googlefonts/fontbakery/issues/2200)


### PR DESCRIPTION
Added to Google Fonts profile.
Detect colliding accents at small point sizes.
(issue #3506)