### PR TITLE
Variable shaping checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the FontWerk Profile
   - **[com.fontwerk/check/inconsistencies_between_fvar_stat]:** Fixed bug that resulted in an ERROR when attempting to access `.AxisIndex` of a format 4 AxisValue table (issue #3904)
 
+#### On the Shaping Profile
+  - All checks can now take a `variations` key in their configuration (either in the default configuration or for each check) specifying the variable font location at which to apply the check.
 
 ## 0.8.10 (2022-Aug-25)
 ### Release Notes

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -412,7 +412,8 @@ def setup_glyph_collides(ttFont, configuration):
         }
     col = Collidoscope(filename,
                        collidoscope_configuration,
-                       direction=configuration.get("direction", "LTR"))
+                       direction=configuration.get("direction", "LTR"),
+                       location=configuration.get("variations"))
     return {"collidoscope": col}
 
 

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -138,6 +138,9 @@ def get_shaping_parameters(test, configuration):
     params = {}
     for el in ["script", "language", "direction", "features", "shaper"]:
         params[el] = get_from_test_with_default(test, configuration, el)
+    variations = get_from_test_with_default(test, configuration, "variations")
+    if variations:
+      params["variations"] = variations
     return params
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ axisregistry==0.3.9
 beautifulsoup4==4.11.1
 beziers==0.5.0
 cmarkgfm==2022.10.27
-collidoscope==0.4.1
+collidoscope==0.6.3
 defcon==0.10.2
 dehinter==4.0.0
 fontTools[ufo,lxml,unicode]==4.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ axisregistry==0.3.9
 beautifulsoup4==4.11.1
 beziers==0.5.0
 cmarkgfm==2022.10.27
-collidoscope==0.6.3
+collidoscope==0.6.5
 defcon==0.10.2
 dehinter==4.0.0
 fontTools[ufo,lxml,unicode]==4.38.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'beautifulsoup4',
         'beziers>=0.5.0', # Uses new fontTools glyph outline access
         'cmarkgfm',
-        'collidoscope==0.6.3',
+        'collidoscope>=0.6.5', # 0.6 series has variable font support
         'defcon',
         'dehinter>=3.1.0', # 3.1.0 added dehinter.font.hint function
         'fontTools[ufo,lxml,unicode]>=4.36.0',  # allows for passing location to glyphsets

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,7 @@ setup(
         'beautifulsoup4',
         'beziers>=0.5.0', # Uses new fontTools glyph outline access
         'cmarkgfm',
-        'collidoscope==0.4.1', # 0.4.0 had a bug that failed to detect
-                               # an ïï collision on Nunito Black.
-                               # (see https://github.com/googlefonts/fontbakery/issues/3554)
+        'collidoscope==0.6.3',
         'defcon',
         'dehinter>=3.1.0', # 3.1.0 added dehinter.font.hint function
         'fontTools[ufo,lxml,unicode]>=4.36.0',  # allows for passing location to glyphsets

--- a/tests/profiles/shaping_test.py
+++ b/tests/profiles/shaping_test.py
@@ -125,3 +125,39 @@ def test_check_shaping_collides():
         assert_results_contain(check(wrap_args(config, font)),
                                FAIL, "shaping-collides",
                                "ïï collides in Nunito")
+
+    # With a variable font
+    shaping_test = {
+        "configuration": {"collidoscope": {"area": 0,
+                                           "bases": True,
+                                           "marks": True},
+                          "variations": {"wght": 400}},
+        "tests": [{"input": "ưï"}],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_gf_dir:
+        json.dump(shaping_test, open(os.path.join(tmp_gf_dir, "test.json"), "w"))
+
+        config = {"com.google.fonts/check/shaping": {"test_directory": tmp_gf_dir}}
+
+        font = TEST_FILE("varfont/OpenSans-Italic[wdth,wght].ttf")
+        assert_PASS(check(wrap_args(config, font)),
+                    "ưï doesn't collide in Open Sans Italic wght=400")
+
+    shaping_test = {
+        "configuration": {"collidoscope": {"area": 0,
+                                           "bases": True,
+                                           "marks": True},
+                          "variations": {"wght": 800}},
+        "tests": [{"input": "ưï"}],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_gf_dir:
+        json.dump(shaping_test, open(os.path.join(tmp_gf_dir, "test.json"), "w"))
+
+        config = {"com.google.fonts/check/shaping": {"test_directory": tmp_gf_dir}}
+
+        font = TEST_FILE("varfont/OpenSans-Italic[wdth,wght].ttf")
+        assert_results_contain(check(wrap_args(config, font)),
+                    FAIL, "shaping-collides",
+                    "ưï collides in Open Sans Italic wght=800")

--- a/tests/profiles/shaping_test.py
+++ b/tests/profiles/shaping_test.py
@@ -47,6 +47,33 @@ def test_check_shaping_regression():
                                FAIL, "shaping-regression",
                                "Slabo: A!=664,V!=691")
 
+    # With a variable font
+    check = CheckTester(universal_profile,
+                        "com.google.fonts/check/shaping/regression")
+
+    shaping_test = {
+        "configuration": {
+            "variations": {"wght": 100 }
+        },
+        "tests": [{"input": "AV",
+                   "expectation": "A=0+1229|V=1+1182",
+                   },
+                  {"input": "AV",
+                   "expectation": "A=0+1487|V=1+1421",
+                   "variations": {"wght": 800 }
+                   }
+                 ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_gf_dir:
+        json.dump(shaping_test, open(os.path.join(tmp_gf_dir, "test.json"), "w"))
+
+        config = {"com.google.fonts/check/shaping": {"test_directory": tmp_gf_dir}}
+
+        font = TEST_FILE("varfont/OpenSans[wdth,wght].ttf")
+        assert_PASS(check(wrap_args(config, font)),
+                    "OpenSans: wght=100, wght=800")
+
 
 def test_check_shaping_forbidden():
     """ Check that we can test for forbidden glyphs in output. """


### PR DESCRIPTION
## Description

This pull request allows checks in the `shaping` profile to be aware of variable fonts. Specifically:

* The `com.google.fonts/check/shaping/regression` check can now serialise buffers at different points in the design space. For example:

```json
{
    "configuration": {
        "variations": {
            "wght": 100
        }
    },
    "tests": [
        {
            "input": "AV",
            "expectation": "A=0+1229|V=1+1182",
        },
        {
            "input": "AV",
            "expectation": "A=0+1487|V=1+1421",
            "variations": { "wght": 800 }
        }
    ]
}
```

This part, represented by the first two commits, should be relatively uncontroversial.

* The `com.google.fonts/check/shaping/collides` check does the same for the collision tester. But it requires the new version of collidoscope (version 0.6.3 or higher). That may be a more controversial update because newer versions of collidoscope are powered by a Rust library (`kurbopy`) and last time an update was suggested there were concerns about the availability of wheels for the `kurbopy` library on different platforms.

## To Do
- [x] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [x] request a review

