### PR TITLE
mock HTTP requests in tests

### DIFF
--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5843,7 +5843,7 @@ def com_google_fonts_check_repo_zip_files(family_directory, config):
 
 @check(
     id="com.google.fonts/check/vertical_metrics",
-    conditions=["not remote_styles", "not is_cjk_font"],
+    conditions=["not listed_on_gfonts_api", "not is_cjk_font"],
     rationale="""
         This check generally enforces Google Fonts’ vertical metrics specifications.
         In particular:
@@ -6146,7 +6146,7 @@ def com_google_fonts_check_vertical_metrics_regressions(
 
 @check(
     id="com.google.fonts/check/cjk_vertical_metrics",
-    conditions=["is_cjk_font", "not remote_styles"],
+    conditions=["is_cjk_font", "not listed_on_gfonts_api"],
     rationale="""
         CJK fonts have different vertical metrics when compared to Latin fonts.
         We follow the schema developed by dr Ken Lunde for Source Han Sans and

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -592,7 +592,7 @@ def github_gfonts_ttFont(ttFont, license_filename):
 
 
 @condition
-def github_gfonts_description(ttFont, license_filename):
+def github_gfonts_description(ttFont, license_filename, config):
     """Get the contents of the DESCRIPTION.en_us.html file
     from the google/fonts github repository corresponding
     to a given ttFont.
@@ -600,8 +600,7 @@ def github_gfonts_description(ttFont, license_filename):
     if not license_filename:
         return None
 
-    from fontbakery.utils import download_file
-    from urllib.request import HTTPError
+    import requests
 
     LICENSE_DIRECTORY = {"OFL.txt": "ofl", "UFL.txt": "ufl", "LICENSE.txt": "apache"}
     filename = os.path.basename(ttFont.reader.file.name)
@@ -611,10 +610,8 @@ def github_gfonts_description(ttFont, license_filename):
         f"/{LICENSE_DIRECTORY[license_filename]}/{familyname}/DESCRIPTION.en_us.html"
     )
     try:
-        descfile = download_file(url)
-        if descfile:
-            return descfile.read().decode("UTF-8")
-    except HTTPError:
+        return requests.get(url, timeout=config.get("timeout")).text
+    except requests.RequestException:
         return None
 
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,3 +5,4 @@ pylint==3.0.2
 sphinx==7.1.2  # Sphinx 7.2.x series requires python >= 3.9
 pytest-cov==4.1.0
 pytest-xdist==3.4.0
+requests-mock==1.10.0

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3851,7 +3851,7 @@ def test_check_vertical_metrics():
     ttFont = TTFont(TEST_FILE("akshar/Akshar[wght].ttf"))
 
     msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
-    assert msg == "Unfulfilled Conditions: not remote_styles"
+    assert msg == "Unfulfilled Conditions: not listed_on_gfonts_api"
 
     # change the font's file name to elude the 'not remote_styles' condition.
     orig_file_name = ttFont.reader.file.name


### PR DESCRIPTION
## Description
I'm working on packaging fontbakery in nixpkgs, which requires that the test suite run without network access. I found a few tests which intentionally make network calls, but in most of them it seems desirable to mock out requests to live services. This will make them faster and more reproducible, and lets them run in an environment like nixpkgs where they are sandboxed from the network.

## To Do
- [ ] update `CHANGELOG.md`
- [ ] wait for all checks to pass
- [ ] request a review

