### PR TITLE
check/STAT/gf_axisregistry: Allow Italic AxisValues in slnt axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the FontWerk Profile
   - **EXPERIMENTAL - [com.fontwerk/check/names_match_default_fvar]:** Check if the font names match default fvar. (PRs #3604 / #3698)
 
+### Deprecated checks
+#### Removed from the Universal Profile
+  - **[com.google.fonts/check/STAT_strings]:** (PR #4215)
+
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/STAT/gf_axisregistry]:** Allow Italic AxisValues in slnt axis. (PR #4215)
+
 
 ## 0.11.1 (2024-Feb-06)
 ### Release highlights & new features

--- a/Lib/fontbakery/checks/googlefonts/axisregistry.py
+++ b/Lib/fontbakery/checks/googlefonts/axisregistry.py
@@ -204,6 +204,13 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont):
             # on the GF Axis Registry for this specific variation axis tag.
             name = normalize_name(name_entry.toUnicode())
             expected_names = [normalize_name(n) for n in fallbacks.keys()]
+
+            # Allow an Italic AxisValue for the slnt axis which can be any
+            # user value.
+            if axis.AxisTag == "slnt" and name == "Italic":
+                yield INFO, Message("italic-detected",
+                                    "Detected an Italic AxisValue for the slnt axis")
+                continue
             if hasattr(axis_value, "Value"):  # Format 1 & 3
                 is_value = axis_value.Value
             elif hasattr(axis_value, "NominalValue"):  # Format 2

--- a/Lib/fontbakery/checks/googlefonts/axisregistry.py
+++ b/Lib/fontbakery/checks/googlefonts/axisregistry.py
@@ -208,8 +208,9 @@ def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont):
             # Allow an Italic AxisValue for the slnt axis which can be any
             # user value.
             if axis.AxisTag == "slnt" and name == "Italic":
-                yield INFO, Message("italic-detected",
-                                    "Detected an Italic AxisValue for the slnt axis")
+                yield INFO, Message(
+                    "italic-detected", "Detected an Italic AxisValue for the slnt axis"
+                )
                 continue
             if hasattr(axis_value, "Value"):  # Format 1 & 3
                 is_value = axis_value.Value

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -1115,53 +1115,6 @@ def com_google_fonts_check_unwanted_tables(ttFont):
 
 
 @check(
-    id="com.google.fonts/check/STAT_strings",
-    conditions=["has_STAT_table"],
-    rationale="""
-        On the STAT table, the "Italic" keyword must not be used on AxisValues
-        for variation axes other than 'ital'.
-    """,
-    proposal="https://github.com/fonttools/fontbakery/issues/2863",
-)
-def com_google_fonts_check_STAT_strings(ttFont):
-    """Check correctness of STAT table strings"""
-    passed = True
-    ital_axis_index = None
-    for index, axis in enumerate(ttFont["STAT"].table.DesignAxisRecord.Axis):
-        if axis.AxisTag == "ital":
-            ital_axis_index = index
-            break
-
-    nameIDs = set()
-    if ttFont["STAT"].table.AxisValueArray:
-        for value in ttFont["STAT"].table.AxisValueArray.AxisValue:
-            if hasattr(value, "AxisIndex"):
-                if value.AxisIndex != ital_axis_index:
-                    nameIDs.add(value.ValueNameID)
-
-            if hasattr(value, "AxisValueRecord"):
-                for record in value.AxisValueRecord:
-                    if record.AxisIndex != ital_axis_index:
-                        nameIDs.add(value.ValueNameID)
-
-    bad_values = set()
-    for name in ttFont["name"].names:
-        if name.nameID in nameIDs and "italic" in name.toUnicode().lower():
-            passed = False
-            bad_values.add(f"nameID {name.nameID}: {name.toUnicode()}")
-
-    if bad_values:
-        yield FAIL, Message(
-            "bad-italic",
-            "The following AxisValue entries on the STAT table"
-            f' should not contain "Italic":\n{sorted(bad_values)}',
-        )
-
-    if passed:
-        yield PASS, "Looks good!"
-
-
-@check(
     id="com.google.fonts/check/valid_glyphnames",
     rationale="""
         Microsoft's recommendations for OpenType Fonts states the following:

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -22,7 +22,6 @@ PROFILE = {
             "com.google.fonts/check/valid_glyphnames",
             "com.google.fonts/check/unique_glyphnames",
             "com.google.fonts/check/family/vertical_metrics",
-            "com.google.fonts/check/STAT_strings",
             "com.google.fonts/check/rupee",
             "com.google.fonts/check/unreachable_glyphs",
             "com.google.fonts/check/contour_count",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -4334,7 +4334,18 @@ def test_check_STAT_gf_axisregistry():
     ttFont["STAT"].table.AxisValueArray.AxisValue[3].Value = 800
     assert_results_contain(check(ttFont), FAIL, "bad-coordinate")
 
-    # Let's remove all Axis Values. This will fail since we Google Fonts
+    # restore good value:
+    ttFont["STAT"].table.AxisValueArray.AxisValue[3].Value = 800
+
+    # We accept name = "Italic" on 'slnt' axis (since PR #4215)
+    assert ttFont["STAT"].table.DesignAxisRecord.Axis[0].AxisTag == "wght"
+    ttFont["STAT"].table.DesignAxisRecord.Axis[0].AxisTag = "slnt"
+    for i in range(7):
+        name = ttFont["name"].names[22 + i]
+        ttFont["name"].names[22 + i].string = "Italic".encode(name.getEncoding())
+    assert_results_contain(check(ttFont), INFO, "italic-detected")
+
+    # Let's remove all Axis Values. This will fail since Google Fonts
     # requires them.
     ttFont["STAT"].table.AxisValueArray = None
     assert_results_contain(check(ttFont), FAIL, "missing-axis-values")

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -993,16 +993,6 @@ def test_check_superfamily_vertical_metrics(
     )
 
 
-def test_check_STAT_strings():
-    check = CheckTester("com.google.fonts/check/STAT_strings")
-
-    good = TTFont(TEST_FILE("ibmplexsans-vf/IBMPlexSansVar-Roman.ttf"))
-    assert_PASS(check(good))
-
-    bad = TTFont(TEST_FILE("ibmplexsans-vf/IBMPlexSansVar-Italic.ttf"))
-    assert_results_contain(check(bad), FAIL, "bad-italic")
-
-
 def test_check_rupee():
     """Ensure indic fonts have the Indian Rupee Sign glyph."""
     check = CheckTester("com.google.fonts/check/rupee")


### PR DESCRIPTION
Check updated based on Rosa's comment in an private repo,

> "We usually only set a default value to 0 in the STAT and no fallback. Although if you want italic instances in the FVAR you would need to add an italic value also in the STAT and the test will fail (but in that case you ignore). if you have italic instances, the slant axis should be last in the axis order. And you would need to link 0 with the italic value. "

@madig would you mind testing this? if you're happy, I'll clean up,

