### PR TITLE
Generalize the grade_reflow check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.9.0 (2023-Aug-??)
+### Changes to existing checks
+#### On the Google Fonts profile
+  - **[com.google.fonts/check/grade_reflow]**: This check has been renamed to **[com.google.fonts/check/varfont/duplexed_axis_reflow]** and now also checks the `ROND` axis. (issue #4200)
+
 ### New Checks
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5933,7 +5933,8 @@ def com_google_fonts_check_varfont_duplexed_axis_reflow(ttFont, config):
                             yield FAIL, Message(
                                 "duplexed-kern-causes-reflow",
                                 f"Kerning rules cause variation in"
-                                f" horizontal advance on a duplexed axis ({relevant_axes_display})"
+                                f" horizontal advance on a duplexed axis "
+                                f" ({relevant_axes_display})"
                                 f" (e.g. {left}/{right})",
                             )
                             bad_kerning = True
@@ -5942,7 +5943,8 @@ def com_google_fonts_check_varfont_duplexed_axis_reflow(ttFont, config):
     # Check kerning here
     if not bad_glyphs and not bad_kerning:
         yield PASS, (
-            "No variations or kern rules vary horizontal advance along any duplexed axes"
+            "No variations or kern rules vary horizontal advance along "
+            "any duplexed axes"
         )
 
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4325,14 +4325,14 @@ def test_check_varfont_unsupported_axes():
     assert_results_contain(check(ttFont), FAIL, "unsupported-ital")
 
 
-def test_check_varfont_grade_reflow():
+def test_check_varfont_duplexed_axis_reflow():
     """Ensure VFs with the GRAD axis do not vary horizontal advance."""
     check = CheckTester(
-        googlefonts_profile, "com.google.fonts/check/varfont/grade_reflow"
+        googlefonts_profile, "com.google.fonts/check/varfont/duplexed_axis_reflow"
     )
 
     ttFont = TTFont(TEST_FILE("BadGrades/BadGrades-VF.ttf"))
-    assert_results_contain(check(ttFont), FAIL, "grad-causes-reflow")
+    assert_results_contain(check(ttFont), FAIL, "duplexed-causes-reflow")
 
     # Zero out the horizontal advances
     gvar = ttFont["gvar"]
@@ -4344,7 +4344,7 @@ def test_check_varfont_grade_reflow():
                 delta.coordinates = delta.coordinates[:-4] + [(0, 0)] * 4
 
     # But the kern rules should still be a problem
-    assert_results_contain(check(ttFont), FAIL, "grad-kern-causes-reflow")
+    assert_results_contain(check(ttFont), FAIL, "duplexed-kern-causes-reflow")
 
     ttFont["GPOS"].table.LookupList.Lookup = []
     assert_PASS(check(ttFont))


### PR DESCRIPTION
## Description
Fixes #4200

This generalises and renames the grade_reflow check to also check for deltas in other "duplexed" axes. So far, only `ROND` has been added, but now the check is general-purpose other axes can be easily added.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [x] request a review

