### PR TITLE
Update is_cjk condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Google Fonts profile
   - **[com.google.fonts/check/font-v]:** Change rationale to reflect the fact that this check emits an INFO (issue #4067)
   - **[com.google.fonts/check/vertical_metrics_regressions]:** Fix an error when the provided font did not have a Regular style. (issue #3897)
+  - **[com.google.fonts/check/cjk_not_enough_glyphs]:** This check is now only run when a font has CJK codepages or ranges declared in the `OS/2` table. Other CJK-related checks are run on fonts with a minimum of 150 CJK glyphs. (issue #3846)
 
 ### New Checks
 #### Added to the Google Fonts Profile

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -575,7 +575,6 @@ CJK_UNICODE_RANGE_BITS = {
     "Hangul Syllables": 56,
     "CJK Unified Ideographs": 59,
     "CJK Strokes": 61,
-    "Yi Syllables": 83,
 }
 
 
@@ -602,8 +601,6 @@ CJK_UNICODE_RANGES = [
     [0x31C0, 0x31EF],  # CJK Strokes
     [0xF900, 0xFAFF],  # CJK Compatibility Ideographs (CJK Strokes)
     [0x2F800, 0x2FA1F],  # CJK Compatibility Ideographs Supplement (CJK Strokes)
-    [0xA000, 0xA48F],  # Yi Syllables
-    [0xA490, 0xA4CF],  # Yi Radicals
 ]
 
 OFL_BODY_TEXT = """

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -5766,9 +5766,9 @@ def com_google_fonts_check_cjk_vertical_metrics_regressions(
 
 @check(
     id="com.google.fonts/check/cjk_not_enough_glyphs",
-    conditions=["is_cjk_font"],
+    conditions=["is_claiming_to_be_cjk_font"],
     rationale="""
-        Hangul has 40 characters and it's the smallest CJK writing system.
+        Kana has 150 characters and it's the smallest CJK writing system.
 
         If a font contains less CJK glyphs than this writing system, we inform the
         user that some glyphs may be encoded incorrectly.
@@ -5776,12 +5776,12 @@ def com_google_fonts_check_cjk_vertical_metrics_regressions(
     proposal="https://github.com/fonttools/fontbakery/pull/3214",
 )
 def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
-    """Does the font contain less than 40 CJK characters?"""
+    """Does the font contain less than 150 CJK characters?"""
     from .shared_conditions import get_cjk_glyphs
 
     cjk_glyphs = get_cjk_glyphs(ttFont)
     cjk_glyph_count = len(cjk_glyphs)
-    if cjk_glyph_count > 0 and cjk_glyph_count < 40:
+    if cjk_glyph_count > 0 and cjk_glyph_count < 150:
         if cjk_glyph_count == 1:
             N_CJK_glyphs = "There is only one CJK glyph"
         else:
@@ -5789,8 +5789,8 @@ def com_google_fonts_check_cjk_not_enough_glyphs(ttFont):
 
         yield WARN, Message(
             "cjk-not-enough-glyphs",
-            f"{N_CJK_glyphs} when there needs to be at least 40"
-            f" in order to support the smallest CJK writing system, Hangul.\n"
+            f"{N_CJK_glyphs} when there needs to be at least 150"
+            f" in order to support the smallest CJK writing system, Kana.\n"
             f"The following CJK glyphs were found:\n"
             f"{cjk_glyphs}\n"
             f"Please check that these glyphs have the correct unicodes.",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4194,12 +4194,15 @@ def test_check_cjk_not_enough_glyphs():
 
     ttFont = TTFont(TEST_FILE("montserrat/Montserrat-Regular.ttf"))
     msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
-    assert msg == "Unfulfilled Conditions: is_cjk_font"
+    assert msg == "Unfulfilled Conditions: is_claiming_to_be_cjk_font"
 
     # Let's modify Montserrat's cmap so there's a cjk glyph
     cmap = ttFont["cmap"].getcmap(3, 1)
     # Add first character of the CJK unified Ideographs
     cmap.cmap[0x4E00] = "A"
+    # And let's declare that we are a CJK font
+    ttFont["OS/2"].ulCodePageRange1 |= 1 << 17
+
     msg = assert_results_contain(check(ttFont), WARN, "cjk-not-enough-glyphs")
     assert msg.startswith("There is only one CJK glyph")
 


### PR DESCRIPTION
## Description
Fixes issue #3846

This turned out to be quite involved, and I needed to make a number of decisions here:

* The suggested strategy was to have the `is_cjk` condition fire if there are more than N CJK glyphs (where N was proposed to be 100). But this would make the `cjk_not_enough_glyphs` check redundant: it would only run on CJK fonts which have more than enough glyphs to pass the check!
* To handle this, I split the condition into two: `is_claiming_to_be_cjk` looks at the metadata in the OS/2 to see if the font has any codepages/Unicode ranges declared, while `is_cjk` checks for a number of encoded CJK glyphs. Most CJK-related checks still use `is_cjk`, apart from `cjk_not_enough_glyphs` because that would be silly as mentioned above, so that check now uses `is_claiming_to_be_cjk`.
* @DavidRaymond suggested we use 100 as the minimum number of CJK glyphs, but `cjk_not_enough_glyphs` has the minimum number set to 40. I investigated this. Our rationale for having 40 was that this would cover Hangul; but it would not! A working Hangul font does not just need the jamo but the encoded syllables as well. Instead, I chose 150 which is roughly the size of a Japanese hiragana/katakana set plus punctuation.
* With all of this, David's original problem still remained - the check was being skipped for Nuosu SIL, and he had suggested that this font should *not* be considered a CJK font. But we were including Yi codepoints as part of our CJK Unicode ranges. This gets into a matter of semantics, of what we mean by "CJK" and what we mean by a "CJK font". The Yi script has many characteristics which make its requirements similar to the requirements of a "CJK" font, but it's clearly not Chinese, Japanese or Korean. Maybe we need better terminology here, and maybe we need to think more about what we're distinguishing when we say "CJK font" and why we want to make that distinction. But at any rate, someone from SIL says that a Yi font should not be considered a CJK font, and I trust that they know best. So I removed the Yi ranges from `CJK_UNICODE_RANGES`.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [x] request a review

