### PR TITLE
Remove `pytest` unrecognized argument `(-n 8)` from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ extend-exclude = '''
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = ["tests"]
-addopts = "-n 8  --color=yes  --verbose"
+addopts = "--color=yes  --verbose"
 filterwarnings = [
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",


### PR DESCRIPTION
The `-n 8` argument from `pyproject.toml` prevents `pytest` from working.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

