### PR TITLE
Add new checks for languagesystem DFLT dflt in UFO sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)
 
+#### Added to the UFO Profile
+  - **[com.thetypefounders/check/features_default_languagesystem]:** Checks if a default languagesystem statement is present in feature files and warns if the compiler will not insert one automatically (issue #4011)
+
 ### Changes to existing checks
 #### On the Universal profile
   - **[com.google.fonts/check/os2_metrics_match_hhea]:** Re-worded rationale text to be vendor-neutral (issue #4206)

--- a/Lib/fontbakery/profiles/ufo_sources.py
+++ b/Lib/fontbakery/profiles/ufo_sources.py
@@ -1,9 +1,12 @@
+import re
+
 from fontbakery.callable import check, condition
-from fontbakery.status import ERROR, FAIL, PASS, WARN
+from fontbakery.status import ERROR, FAIL, PASS, SKIP, WARN
 from fontbakery.section import Section
 from fontbakery.message import Message
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.utils import exit_with_install_instructions
+
 
 profile = profile_factory(default_section=Section("UFO Sources"))
 
@@ -16,6 +19,7 @@ UFO_PROFILE_CHECKS = [
     "com.google.fonts/check/designspace_has_default_master",
     "com.google.fonts/check/designspace_has_consistent_glyphset",
     "com.google.fonts/check/designspace_has_consistent_codepoints",
+    "com.thetypefounders/check/features_default_languagesystem",
 ]
 
 
@@ -301,6 +305,49 @@ def com_google_fonts_check_designspace_has_consistent_codepoints(designSpace, co
         )
     else:
         yield PASS, "Unicode assignments were consistent."
+
+
+@check(
+    id="com.thetypefounders/check/features_default_languagesystem",
+    conditions=["ufo_font"],
+    rationale="""
+        The feature file specification strongly recommends to use a
+        `languagesystem DFLT dflt` statement in your feature file. This
+        statement is automatically inserted when no `languagesystem`
+        statements are present in the feature file, *unless* there is
+        another `languagesystem` statement already present. If this is
+        the case, this behaviour could lead to unintended side effects.
+
+        This check only WARNs when this happen as there are cases where
+        not having a `languagesystem DFLT dflt` statement in your feature
+        file is technically correct.
+
+        http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#4b-language-system
+    """,
+    proposal="https://github.com/googlefonts/fontbakery/issues/4011",
+)
+def com_thetypefounders_check_features_default_languagesystem(ufo_font):
+    """Check that languagesystem DFLT dflt is present in the features.fea file."""
+
+    if ufo_font.features.text is None:
+        yield SKIP, "No features.fea file in font."
+    elif not ufo_font.features.text.strip():
+        yield PASS, "Default languagesystem inserted by compiler."
+    else:
+        tags = re.findall(
+            # pylint: disable-next=line-too-long
+            r"languagesystem\s+([A-Za-z0-9\._!$%&*+:?^'|~]{1,4})\s+([A-Za-z0-9\._!$%&*+:?^'|~]{1,4})",
+            ufo_font.features.text,
+        )
+
+        if len(tags) > 0 and ("DFLT", "dflt") != tags[0]:
+            tags_str = ", ".join([" ".join(t) for t in tags])
+            yield WARN, Message(
+                "default-languagesystem",
+                f"Default languagesystem not found in: {tags_str}.",
+            )
+        else:
+            yield PASS, "Default languagesystem present or automatically inserted."
 
 
 profile.auto_register(globals())

--- a/Lib/fontbakery/profiles/ufo_sources.py
+++ b/Lib/fontbakery/profiles/ufo_sources.py
@@ -336,7 +336,7 @@ def com_thetypefounders_check_features_default_languagesystem(ufo_font):
     else:
         tags = re.findall(
             # pylint: disable-next=line-too-long
-            r"languagesystem\s+([A-Za-z0-9\._!$%&*+:?^'|~]{1,4})\s+([A-Za-z0-9\._!$%&*+:?^'|~]{1,4})",
+            r"languagesystem\s+([A-Za-z0-9\._!$%&*+:?^'|~]{1,4})\s+([A-Za-z0-9\._!$%&*+:?^'|~]{1,4})",  # noqa E501
             ufo_font.features.text,
         )
 


### PR DESCRIPTION
## Description

This adds a new check that tests for the presence of a `languagesystem DFLT dflt` statement in UFO feature files. If a feature file contains no `languagesystem` statements the compiler will automatically insert one, but will not do so if there is another `languagesystem` statement present (which may or not be the `DFLT dflt`). Warn in this case as it may lead to unexpected side effects (such as OT features not working for the default language).

Fixes #4011

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

