### PR TITLE
Downgrade PANOSE consistency checks to warnings instead of failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/grade_reflow]**: This check has been renamed to **com.google.fonts/check/varfont/duplexed_axis_reflow** and now also checks the `ROND` axis. (issue #4200)
   - **[com.google.fonts/check/glyph_coverage]:** This check is now skipped for icon fonts. (issues #3323 and #3327)
 
+#### On the OpenType profile
+  - **[com.google.fonts/check/family/panose_familytype], [com.google.fonts/check/family/panose_proportion]:** Failures have been downgraded to warnings. (issue #4192)
 
 ## 0.9.0a2 (2023-Aug-04)
 ### Changes to existing checks

--- a/Lib/fontbakery/profiles/os2.py
+++ b/Lib/fontbakery/profiles/os2.py
@@ -35,7 +35,7 @@ def com_google_fonts_check_family_panose_proportion(ttFonts):
         )
 
     if not passed:
-        yield FAIL, Message(
+        yield WARN, Message(
             "inconsistency",
             "PANOSE proportion is not the same across this family."
             " In order to fix this, please make sure that"
@@ -71,7 +71,7 @@ def com_google_fonts_check_family_panose_familytype(ttFonts):
         )
 
     if not passed:
-        yield FAIL, Message(
+        yield WARN, Message(
             "inconsistency",
             "PANOSE family type is not the same across this family."
             " In order to fix this, please make sure that"

--- a/tests/profiles/os2_test.py
+++ b/tests/profiles/os2_test.py
@@ -60,7 +60,7 @@ def test_check_family_panose_proportion(mada_ttFonts):
     mada_ttFonts[0]["OS/2"].panose.bProportion = incorrect_value
 
     assert_results_contain(
-        check(mada_ttFonts), FAIL, "inconsistency", "with inconsistent family."
+        check(mada_ttFonts), WARN, "inconsistency", "with inconsistent family."
     )
 
 
@@ -78,7 +78,7 @@ def test_check_family_panose_familytype(mada_ttFonts):
     mada_ttFonts[0]["OS/2"].panose.bFamilyType = incorrect_value
 
     assert_results_contain(
-        check(mada_ttFonts), FAIL, "inconsistency", "with inconsistent family."
+        check(mada_ttFonts), WARN, "inconsistency", "with inconsistent family."
     )
 
 


### PR DESCRIPTION
## Description

This changes the PANOSE consistency checks from failures to warnings due to there being valid reasons for inconsistent values and low usage of PANOSE in general.

Fixes #4192

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

