### PR TITLE
New Check: FAIL on bad postscript names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.9.0 (2023-Sep-??)
-  - ...
+### New Checks
+#### Added to the OpenType Profile
+  - **[com.adobe.fonts/check/postscript_name]:** FAIL on bad postscript names (issue #4254).
+
+### Changes to existing checks
+#### On the OpenType Profile
+  - **[com.google.fonts/check/family_naming_recommendations]:** Two validations of PostScript names were moved out of this check and into **com.adobe.fonts/check/postscript_name** which yields FAILs (issue #4254).
 
 
-## Upcoming release: 0.9.0a3 (2023-Sep-05)
+## 0.9.0a3 (2023-Sep-05)
 ### Note-worthy code changes
   - The default log level has been changed to WARN. Now that profiles are big, you don't (by default) want a big long list of everything that is OK about your font; you just want to know the problems to fix. Make WARN the default and have people get a list of PASS if they ask for it. (issue #4186)
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -26,7 +26,7 @@ profile = profile_factory(default_section=Section("Adobe Fonts"))
 SET_EXPLICIT_CHECKS = {
     # This is the set of explict checks that will be invoked
     # when fontbakery is run with the 'check-adobefonts' subcommand.
-    # The contents of this set were last updated on April 19, 2023.
+    # The contents of this set were last updated on September 6, 2023.
     #
     # =======================================
     # From adobefonts.py (this file)
@@ -132,6 +132,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/family/max_4_fonts_per_family_name",
     "com.adobe.fonts/check/family/consistent_family_name",
     "com.adobe.fonts/check/name/empty_records",
+    "com.adobe.fonts/check/postscript_name",
     "com.adobe.fonts/check/name/postscript_name_consistency",
     "com.adobe.fonts/check/name/postscript_vs_cff",
     "com.google.fonts/check/family_naming_recommendations",

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -419,12 +419,11 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
 
 @check(
-    id="com.google.fonts/check/family_naming_recommendations",
-    proposal="legacy:check/071",
+    id="com.adobe.fonts/check/postscript_name",
+    proposal="https://github.com/miguelsousa/openbakery/issues/62",
 )
-def com_google_fonts_check_family_naming_recommendations(ttFont):
-    """Font follows the family naming recommendations?"""
-    # See http://forum.fontlab.com/index.php?topic=313.0
+def com_adobe_fonts_check_postscript_name(ttFont):
+    """PostScript name follows OpenType specification requirements?"""
     import re
     from fontbakery.utils import get_name_entry_strings
 
@@ -439,7 +438,7 @@ def com_google_fonts_check_family_naming_recommendations(ttFont):
                 {
                     "field": "PostScript Name",
                     "value": string,
-                    "rec": ("May contain only a-zA-Z0-9 characters and an hyphen."),
+                    "rec": ("May contain only a-zA-Z0-9 characters and a hyphen."),
                 }
             )
         if string.count("-") > 1:
@@ -447,9 +446,34 @@ def com_google_fonts_check_family_naming_recommendations(ttFont):
                 {
                     "field": "Postscript Name",
                     "value": string,
-                    "rec": ("May contain not more than a single hyphen"),
+                    "rec": ("May contain not more than a single hyphen."),
                 }
             )
+
+    if len(bad_entries) > 0:
+        table = "| Field | Value | Recommendation |\n"
+        table += "|:----- |:----- |:-------------- |\n"
+        for bad in bad_entries:
+            table += "| {} | {} | {} |\n".format(bad["field"], bad["value"], bad["rec"])
+        yield FAIL, Message(
+            "bad-psname-entries",
+            f"PostScript name does not follow requirements:\n\n{table}",
+        )
+    else:
+        yield PASS, Message("psname-ok", "PostScript name follows requirements.")
+
+
+@check(
+    id="com.google.fonts/check/family_naming_recommendations",
+    proposal="legacy:check/071",
+)
+def com_google_fonts_check_family_naming_recommendations(ttFont):
+    """Font follows the family naming recommendations?"""
+    # See http://forum.fontlab.com/index.php?topic=313.0
+
+    from fontbakery.utils import get_name_entry_strings
+
+    bad_entries = []
 
     for string in get_name_entry_strings(ttFont, NameID.FULL_FONT_NAME):
         if len(string) >= 64:

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -70,6 +70,7 @@ OPENTYPE_PROFILE_CHECKS = [
     "com.google.fonts/check/glyf_unused_data",
     "com.google.fonts/check/family_naming_recommendations",
     "com.google.fonts/check/maxadvancewidth",
+    "com.adobe.fonts/check/postscript_name",
     "com.google.fonts/check/points_out_of_bounds",
     "com.google.fonts/check/glyf_non_transformed_duplicate_components",
     "com.google.fonts/check/code_pages",

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -61,7 +61,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 80
+    assert len(SET_EXPLICIT_CHECKS) == 81
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS


### PR DESCRIPTION
- Added to the OpenType Profile
- com.adobe.fonts/check/postscript_name
- Implemented by Josh Hadley at https://github.com/miguelsousa/openbakery/pull/63
- Ported to FontBakery by FSanches.

Note: These validations were previously INFO-level and were
      part of com.google.fonts/check/family_naming_recommendations
      which was also updated.

(issue #4254)