### PR TITLE
Fix yet another error on fonts without ASCII letters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ A more detailed list of changes is available in the corresponding milestones for
   - ...
 
 
+## 0.9.2 (2023-Sep-20)
+### Bug Fixes
+#### On the Universal Profile
+  - **[com.google.fonts/check/font_is_centered_vertically]:** Fix yet another error on fonts without ASCII letters (issue #4269)
+
+
 ## 0.9.1 (2023-Sep-19)
 ### Stable release notes
   - Guido Ferreyra from Type Network contributed improvements to the HTML Reporter which now displays vendor-specific branding (like logo and custom header text - whenever provided). This also includes improvements on the layout of the HTML page with the goal of improving readability of the reports. (PRs #4260 and #4263)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -281,7 +281,6 @@ def com_google_fonts_check_family_single_directory(fonts):
 
 @check(
     id="com.google.fonts/check/caps_vertically_centered",
-    proposal="https://github.com/fonttools/fontbakery/issues/4139",
     rationale="""
         This check suggests one possible approach to designing vertical metrics,
         but can be ingnored if you follow a different approach.
@@ -293,23 +292,26 @@ def com_google_fonts_check_family_single_directory(fonts):
         There is a detailed description of this subject at:
         https://x.com/romanshamin_en/status/1562801657691672576
     """,
+    proposal="https://github.com/fonttools/fontbakery/issues/4139",
 )
 def com_google_fonts_check_caps_vertically_centered(ttFont):
     """Check if uppercase glyphs are vertically centered."""
     from fontTools.pens.boundsPen import BoundsPen
 
+    SOME_UPPERCASE_GLYPHS = ["A", "B", "C", "D", "E", "H", "I", "M", "O", "S", "T", "X"]
     glyphSet = ttFont.getGlyphSet()
-    highest_point_list = []
-    if "A" not in glyphSet.keys():
-        yield SKIP, Message(
-            "lacks-ascii",
-            "The implementation of this check relies on"
-            " uppercase latin characteres that are not"
-            " available in this font.",
-        )
-        return
 
-    for glyphName in ["A", "B", "C", "D", "E", "H", "I", "M", "O", "S", "T", "X"]:
+    for glyphname in SOME_UPPERCASE_GLYPHS:
+        if glyphname not in glyphSet.keys():
+            yield SKIP, Message(
+                "lacks-ascii",
+                "The implementation of this check relies on a few samples"
+                " of uppercase latin characteres that are not available in this font.",
+            )
+            return
+
+    highest_point_list = []
+    for glyphName in SOME_UPPERCASE_GLYPHS:
         pen = BoundsPen(glyphSet)
         glyphSet[glyphName].draw(pen)
         highest_point = pen.bounds[3]


### PR DESCRIPTION
**com.google.fonts/check/font_is_centered_vertically** on the `Universal` profile.
(issue #4269)