### PR TITLE
Improve unreachable subsetting check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)
+  - **[com.google.fonts/check/metadata/unreachable_subsetting]:** Report codepoints in supplementary Unicode planes, and codepoints with no glyphset support at all (PR #4273)
 
 #### Added to the UFO Profile
   - **[com.thetypefounders/check/features_default_languagesystem]:** Checks if a default languagesystem statement is present in feature files and warns if the compiler will not insert one automatically (issue #4011)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Bug Fixes
 #### On the Universal Profile
   - **[com.google.fonts/check/font_is_centered_vertically]:** Fix yet another error on fonts without ASCII letters (issue #4269)
-
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/unreachable_subsetting]:** Report codepoints in supplementary Unicode planes, and codepoints with no glyphset support at all (PR #4273)
 
 ## 0.9.1 (2023-Sep-19)
 ### Stable release notes
@@ -76,7 +77,6 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### Added to the Google Fonts Profile
   - **[com.google.fonts/check/metadata/primary_script]:** New check that guesses the primary script and compares to METADATA.pb (issue #4109)
-  - **[com.google.fonts/check/metadata/unreachable_subsetting]:** Report codepoints in supplementary Unicode planes, and codepoints with no glyphset support at all (PR #4273)
 
 #### Added to the UFO Profile
   - **[com.thetypefounders/check/features_default_languagesystem]:** Checks if a default languagesystem statement is present in feature files and warns if the compiler will not insert one automatically (issue #4011)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1159,7 +1159,10 @@ def com_google_fonts_check_metadata_unsupported_subsets(
         will not be served in the subsetted fonts, and so will be unreachable to
         the end user.
     """,
-    proposal="https://github.com/fonttools/fontbakery/issues/4097",
+    proposal=[
+        "https://github.com/fonttools/fontbakery/issues/4097",
+        "https://github.com/fonttools/fontbakery/pull/4273",
+    ],
     severity=2,
 )
 def com_google_fonts_check_metadata_unreachable_subsetting(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1043,14 +1043,7 @@ def com_google_fonts_check_vendor_id(ttFont, registered_vendor_ids):
 
 @condition
 def font_codepoints(ttFont):
-    codepoints = set()
-    for table in ttFont["cmap"].tables:
-        if (
-            table.platformID == PlatformID.WINDOWS
-            and table.platEncID == WindowsEncodingID.UNICODE_BMP
-        ):
-            codepoints.update(table.cmap.keys())
-    return codepoints
+    return set(ttFont.getBestCmap().keys())
 
 
 @check(

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,8 @@ setup(
     python_requires=">=3.8",
     setup_requires=[
         "setuptools>=61.2",
-        "setuptools_scm[toml]>=6.2",
+        "setuptools_scm[toml]>=6.2, !=8.0.0",  # version 8.0.0 had a bug as described at
+        # https://github.com/pypa/setuptools_scm/issues/905
     ],
     install_requires=[
         # ---

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -5188,6 +5188,14 @@ def test_check_metadata_unreachable_subsetting():
         check(font), WARN, "unreachable-subsetting", "with a bad font"
     )
 
+    font = TEST_FILE("playfair/Playfair-Italic[opsz,wdth,wght].ttf")
+    assert_results_contain(
+        check(font),
+        WARN,
+        "unreachable-subsetting",
+        "with a bad font and no METADATA.pb",
+    )
+
 
 def test_check_alt_caron():
     """Check accent of Lcaron, dcaron, lcaron, tcaron"""


### PR DESCRIPTION
## Description

This improves the `com.google.fonts/check/metadata/unreachable_subsetting` check in a number of ways:

* First, the condition `font_codepoints` was buggy! It searched through cmap tables to find those which are platform=Windows encoding=Unicode_BMP - which is fine if your font has codepoints exclusively within the BMP! I fixed it to use `ttFont.getBestCmap()`, which is simpler and also allows for cmap tables containing codepoints in supplementary planes.
* Second, we previously did not warn about codepoints which are subsetted out because they were not covered in any glyphset definition at all. This makes sense because it's not a font bug (it's a glyphsets one!) but it turns out that it's actually very useful to know how much of your font will just get dropped on the floor.
* Finally, this check only makes sense inside `google/fonts`, i.e. when you have a METADATA.pb file already. But it's also useful to be able to check during development (i.e. when you are upstream of google/fonts) if any codepoints will get left behind. We do this by copying the behaviour of the packager in how it detects subsets within a font, and using that information if a METADATA.pb file is not present.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

