### PR TITLE
Temporarily disable check/caps_vertically_centered (on the universal profile) until the calculation is properly reviewed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ A more detailed list of changes is available in the corresponding milestones for
   - ...
 
 
-## 0.9.2 (2023-Sep-21)
+## 0.9.2 (2023-Sep-22)
+### Stable release notes
+  - **[com.google.fonts/check/caps_vertically_centered]** was temporarily disabled, until the calculations are properly reviewed. (issue #4274)
+
 ### Changes to existing checks
 #### On the Universal profile
-  - **[com.google.fonts/check/font_is_centered_vertically]:** Fix yet another ERROR on fonts without ASCII letters (issue #4269)
+  - **[com.google.fonts/check/caps_vertically_centered]:** Fix yet another ERROR on fonts without ASCII letters (issue #4269)
   - **[com.google.fonts/check/contour_count]:** This check now FAILs if a glyph which should have contours is found to have no contours (issue #4137)
 
 #### On the Google Fonts Profile
@@ -23,7 +26,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Bug Fixes
 #### On the Universal Profile
-  - **[com.google.fonts/check/font_is_centered_vertically]:** Fix error on font without ASCII letters (issue #4265)
+  - **[com.google.fonts/check/caps_vertically_centered]:** Fix error on font without ASCII letters (issue #4265)
 
 ### New Checks
 #### Added to the TypeNetwork Profile

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -3,7 +3,7 @@ import re
 
 from packaging.version import VERSION_PATTERN
 
-from fontbakery.callable import check
+from fontbakery.callable import check, disable
 from fontbakery.constants import PlatformID, WindowsEncodingID
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.glyphdata import desired_glyph_data
@@ -59,7 +59,7 @@ UNIVERSAL_PROFILE_CHECKS = (
         "com.google.fonts/check/cjk_chws_feature",
         "com.google.fonts/check/transformed_components",
         "com.google.fonts/check/gpos7",
-        "com.google.fonts/check/caps_vertically_centered",
+        # "com.google.fonts/check/caps_vertically_centered",  # Disabled: issue #4274
         "com.google.fonts/check/ots",
         "com.adobe.fonts/check/freetype_rasterizer",
         "com.adobe.fonts/check/sfnt_version",
@@ -279,6 +279,7 @@ def com_google_fonts_check_family_single_directory(fonts):
         )
 
 
+@disable
 @check(
     id="com.google.fonts/check/caps_vertically_centered",
     rationale="""

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1374,7 +1374,7 @@ def test_check_alt_caron():
     assert_PASS(check(ttFont))
 
 
-def test_check_caps_vertically_centered():
+def DISABLED_test_check_caps_vertically_centered():
     """Check if uppercase glyphs are vertically centered."""
 
     check = CheckTester(


### PR DESCRIPTION
(issue #4274)