### PR TITLE
Fix ERROR on `check/description/urls` due to trying to call `startswith` method on NoneType.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.9.3 (2023-Sep-??)
-  - ...
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/description/urls]:** fixed an ERROR due to trying to call `startswith` method on NoneType (issue #4283)
 
 
 ## 0.9.2 (2023-Sep-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.9.3 (2023-Sep-??)
 ### Changes to existing checks
 #### On the Google Fonts Profile
-  - **[com.google.fonts/check/description/urls]:** fixed an ERROR due to trying to call `startswith` method on NoneType (issue #4283)
+  - **[com.google.fonts/check/description/urls]:** fixed an ERROR due to trying to call `startswith` method on NoneType. Also upgrade check to FAIL and report any links with empty text content. (issue #4283)
 
 
 ## 0.9.2 (2023-Sep-23)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -338,7 +338,7 @@ def com_google_fonts_check_description_broken_links(description_html):
         family webpage on the Google Fonts website.
 
         Google Fonts has a content formatting policy for that snippet that expects the
-        text content of links not to include the http:// or https:// prefixes.
+        text content of anchors not to include the http:// or https:// prefixes.
     """,
     proposal=[
         "https://github.com/fonttools/fontbakery/issues/3497",
@@ -354,7 +354,8 @@ def com_google_fonts_check_description_urls(description_html):
             if a_href.attrib:
                 yield FAIL, Message(
                     "empty-link-text",
-                    f"The following link has empty text:\n\n{a_href.attrib}\n",
+                    "The following anchor has empty text content:\n\n"
+                    f"{a_href.attrib}\n",
                 )
             continue
 
@@ -362,8 +363,8 @@ def com_google_fonts_check_description_urls(description_html):
             passed = False
             yield FAIL, Message(
                 "prefix-found",
-                f'Please remove the "http(s)://"'
-                f' prefix from the link text "{link_text}"',
+                'Please remove the "http(s)://" prefix from the text content'
+                f" of the following anchor:\n\n{link_text}",
             )
             continue
 

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -347,6 +347,9 @@ def com_google_fonts_check_description_urls(description_html):
     passed = True
     for a_href in description_html.iterfind(".//a[@href]"):
         link_text = a_href.text
+        if not link_text:
+            continue
+
         if link_text.startswith("http://") or link_text.startswith("https://"):
             passed = False
             yield WARN, Message(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -340,7 +340,10 @@ def com_google_fonts_check_description_broken_links(description_html):
         Google Fonts has a content formatting policy for that snippet that expects the
         text content of links not to include the http:// or https:// prefixes.
     """,
-    proposal="https://github.com/fonttools/fontbakery/issues/3497",
+    proposal=[
+        "https://github.com/fonttools/fontbakery/issues/3497",
+        "https://github.com/fonttools/fontbakery/issues/4283",
+    ],
 )
 def com_google_fonts_check_description_urls(description_html):
     """URLs on DESCRIPTION file must not display http(s) prefix."""
@@ -348,11 +351,16 @@ def com_google_fonts_check_description_urls(description_html):
     for a_href in description_html.iterfind(".//a[@href]"):
         link_text = a_href.text
         if not link_text:
+            if a_href.attrib:
+                yield FAIL, Message(
+                    "empty-link-text",
+                    f"The following link has empty text:\n\n{a_href.attrib}\n",
+                )
             continue
 
         if link_text.startswith("http://") or link_text.startswith("https://"):
             passed = False
-            yield WARN, Message(
+            yield FAIL, Message(
                 "prefix-found",
                 f'Please remove the "http(s)://"'
                 f' prefix from the link text "{link_text}"',

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -4763,10 +4763,15 @@ def test_check_description_urls():
     assert_PASS(check(font))
 
     font = TEST_FILE("cabinvfbeta/CabinVFBeta.ttf")
-    assert_results_contain(check(font), WARN, "prefix-found")
+    assert_results_contain(check(font), FAIL, "prefix-found")
 
     good_desc = check["description"].replace(">https://", ">")
     assert_PASS(check(font, {"description": good_desc}))
+
+    bad_desc = check["description"].replace(">github.com/impallari/Cabin<", "><")
+    assert_results_contain(
+        check(font, {"description": bad_desc}), FAIL, "empty-link-text"
+    )
 
 
 def test_check_metadata_unsupported_subsets():


### PR DESCRIPTION
**com.google.fonts/check/description/urls** on `Google Fonts` profile.

(issue #4283)