### PR TITLE
Report missing `source.repository_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.9.3 (2023-Sep-??)
 ### Changes to existing checks
 #### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/consistent_repo_urls]:** Report missing source.repository_url (issue #4285)
   - **[com.google.fonts/check/description/urls]:** fixed an ERROR due to trying to call `startswith` method on NoneType. Also upgrade check to FAIL and report any links with empty text content. (issue #4283)
 
 

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2581,6 +2581,14 @@ def test_check_metadata_consistent_repo_urls():
     )
     assert_PASS(check(ttFont, {"family_metadata": family_md}))
 
+    family_md.source.repository_url = ""
+    assert_results_contain(
+        check(ttFont, {"family_metadata": family_md}),
+        FAIL,
+        "lacks-repo-url",
+        "when the field is either empty or completley missing...",
+    )
+
 
 def test_check_metadata_primary_script():
     """METADATA.pb: Check for primary_script"""


### PR DESCRIPTION
**com.google.fonts/check/metadata/consistent_repo_urls**
On the Google Fonts profile.
(issue #4285)