### PR TITLE
Remove vf_has_static_fonts check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/metadata/consistent_repo_urls]:** Report missing source.repository_url (issue #4285), check with other sources (issue #3521), test repo URL more flexibly (issue #4107)
   - **[com.google.fonts/check/description/urls]:** fixed an ERROR due to trying to call `startswith` method on NoneType. Also upgrade check to FAIL and report any links with empty text content. (issue #4283)
   - **[com.google.fonts/check/glyph_coverage]:** Only check for GF Latin Kernel when fonts have a primary_script set. (issue #4111)
+  - **[com.google.fonts/check/vf_has_static_fonts]:** This check now allows manually-hinted static fonts but otherwise warns if fonts are found in the static/ directory. (issue #4092)
 
 #### On the Universal Profile
   - **[com.google.fonts/check/interpolation_issues]:** Improved the warning message to show the actual master locations. (PR #4288)

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -3688,34 +3688,35 @@ def test_check_repo_vf_has_static_fonts(tmp_path):
 
     shutil.copytree(src_family, family_dir, dirs_exist_ok=True)
 
-    assert_results_contain(
+    assert_PASS(
         check(dir_path, {"family_directory": family_dir}),
-        WARN,
-        "missing",
-        "for a VF family which does not has a static dir.",
+        "for a VF family which does not have a static dir.",
     )
 
     static_dir = family_dir / "static"
     static_dir.mkdir()
-    assert_results_contain(
-        check(dir_path, {"family_directory": family_dir}),
-        FAIL,
-        "empty",
-        "for a VF family which has a static dir but no fonts in the static dir.",
-    )
-
-    static_fonts = portable_path("data/test/cabin")
+    static_fonts = portable_path("data/test/ibmplexsans-vf")
     shutil.rmtree(static_dir)
     shutil.copytree(static_fonts, static_dir)
     assert_PASS(
         check(dir_path, {"family_directory": family_dir}),
-        "for a VF family which has a static dir and static fonts",
+        "for a VF family which has a static dir and manually hinted static fonts",
     )
 
-    msg = assert_results_contain(
-        check("", {"family_directory": family_dir}), SKIP, "unfulfilled-conditions"
+    static_fonts = portable_path("data/test/overpassmono")
+    shutil.rmtree(static_dir)
+    static_dir.mkdir()
+    shutil.copyfile(
+        os.path.join(static_fonts, "OverpassMono-Regular.ttf"),
+        static_dir / "OverpassMono-Regular.ttf",
     )
-    assert msg == "Unfulfilled Conditions: gfonts_repo_structure"
+
+    assert_results_contain(
+        check(dir_path, {"family_directory": family_dir}),
+        WARN,
+        "not-manually-hinted",
+        "for a VF family which has a static dir but no manually hinted static fonts",
+    )
 
 
 def test_check_repo_upstream_yaml_has_required_fields():


### PR DESCRIPTION
## Description
Relates to issue #4092. This check has been reworked: it now checks to see if there are any files in the `static` directory which are not manually-hinted fonts, and warns if so.

## Checklist
- [X] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

