### PR TITLE
Make OFL_body_text check less strict on formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.10.1 (2023-Oct-??)
-  - ...
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/license/OFL_body_text]:** Make the check more tolerant to minor and negligible differences on the contents of the OFL license text, ignoring white space (tabs, line-breaks and space chars). (issue #4289)
 
 
 ## 0.10.0 (2023-Oct-12)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1458,8 +1458,11 @@ def com_google_fonts_check_license_OFL_copyright(license_contents):
 def com_google_fonts_check_license_OFL_body_text(license_contents):
     """Check OFL body text is correct."""
     from fontbakery.constants import OFL_BODY_TEXT
+    from fontbakery.utils import remove_white_space
 
-    if OFL_BODY_TEXT not in license_contents.replace("http://", "https://"):
+    if remove_white_space(OFL_BODY_TEXT) not in remove_white_space(
+        license_contents.replace("http://", "https://")
+    ):
         yield FAIL, Message(
             "incorrect-ofl-body-text",
             "The OFL.txt body text is incorrect. Please use"

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -40,6 +40,13 @@ def exit_with_install_instructions():
     )
 
 
+def remove_white_space(s):
+    s = s.replace(" ", "")
+    s = s.replace("\t", "")
+    s = s.replace("\n", "")
+    return s
+
+
 # TODO: this should be part of FontBakeryCheck and check.conditions
 # should be a tuple (negated, name)
 def is_negated(name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,12 @@ def test_exit_with_install_instructions():
         )
 
 
+def test_remove_white_space():
+    from fontbakery.utils import remove_white_space
+
+    assert remove_white_space("\t  ab \n\tcd  ef ") == "abcdef"
+
+
 @pytest.mark.parametrize(
     "input_str, expected_tup",
     [


### PR DESCRIPTION
**com.google.fonts/check/license/OFL_body_text** on the Google Fonts Profile

Make the check more tolerant to minor and negligible differences on the contents of the OFL license text, ignoring white space (tabs, line-breaks and space chars).
(issue #4289)