### PR TITLE
Rename and rework equal_numbers_of_glyphs check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/license/OFL_body_text]:** Make the check more tolerant to minor and negligible differences on the contents of the OFL license text, ignoring white space (tabs, line-breaks and space chars). (issue #4289)
+  - **[com.google.fonts/check/family/equal_numbers_of_glyphs]:** This check has been reworked, re-enabled and renamed to `com.google.fonts/check/family/equal_codepoint_coverage`. It now checks that the encoded glyphset is consistent across a family. (issue #4180)
 
 
 ## 0.10.0 (2023-Oct-12)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -834,7 +834,8 @@ def com_google_fonts_check_metadata_category(family_metadata):
 @check(
     id="com.google.fonts/check/family/equal_codepoint_coverage",
     conditions=["are_ttf", "stylenames_are_canonical"],
-    proposal="legacy:check/011",
+    proposal="https://github.com/fonttools/fontbakery/issues/4180",
+    experimental="Since 2023-Oct-13",
 )
 def com_google_fonts_check_family_equal_codepoint_coverage(ttFonts, config):
     """Fonts have equal codepoint coverage"""

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -757,23 +757,22 @@ def test_check_metadata_undeclared_fonts():
     assert_PASS(check(font))
 
 
-@pytest.mark.skip(reason="re-enable after addressing issue #1998")
-def test_check_family_equal_numbers_of_glyphs(mada_ttFonts, cabin_ttFonts):
-    """Fonts have equal numbers of glyphs?"""
+def test_check_family_equal_codepoint_coverage(mada_ttFonts, cabin_ttFonts):
+    """Fonts have equal codepoint coverage?"""
     check = CheckTester(
-        googlefonts_profile, "com.google.fonts/check/family/equal_numbers_of_glyphs"
+        googlefonts_profile, "com.google.fonts/check/family/equal_codepoint_coverage"
     )
 
     # our reference Cabin family is know to be good here.
     assert_PASS(check(cabin_ttFonts), "with a good family.")
 
-    # our reference Mada family is bad here with 407 glyphs on most font files
-    # except the Black and the Medium, that both have 408 glyphs.
+    # Let's de-encode some glyphs
+    del cabin_ttFonts[1]["cmap"].tables[0].cmap[8730]
     assert_results_contain(
-        check(mada_ttFonts),
+        check(cabin_ttFonts),
         FAIL,
-        "glyph-count-diverges",
-        "with fonts that diverge on number of glyphs.",
+        "glyphset-diverges",
+        "with fonts that diverge.",
     )
 
 


### PR DESCRIPTION
## Description
Relates to issue #4180. The old `equal_numbers_of_glyphs` check is now `equal_codepoint_coverage`, and ensures that encoded glyphsets are consistent across a family. (see also #1998)

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

