### PR TITLE
New checks: Arabic spacing symbols aren't classified as marks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@ Below are the most important changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## Upcoming release: 0.10.2 (2023-Oct-??)
+## Upcoming release: 0.10.3 (2023-Oct-??)
+  - ...
+
+
+## 0.10.2 (2023-Oct-20)
+### New checks
+#### Added to the Universal Profile
+  - **EXPERIMENTAL - [com.google.fonts/check/arabic_spacing_symbols]:** Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks. (issue #4295)
+
 ### Changes to existing checks
 #### On the Universal Profile
   - **EXPERIMENTAL - [com.google.fonts/check/legacy_accents]:** Legacy accents cannot have zero-width. Previously we were expecting those to not be "too narrow". (issue #4310)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -70,6 +70,7 @@ UNIVERSAL_PROFILE_CHECKS = (
         "com.google.fonts/check/linegaps",
         "com.google.fonts/check/STAT_in_statics",
         "com.google.fonts/check/alt_caron",
+        "com.google.fonts/check/arabic_spacing_symbols",
     ]
 )
 
@@ -754,6 +755,64 @@ def com_google_fonts_check_legacy_accents(ttFont):
                         "legacy-accents-gdef",
                         f'Legacy accent "{glyph.name}" is defined in GDEF'
                         f" as a mark (class 3).",
+                    )
+
+    if passed:
+        yield PASS, "Looks good!"
+
+
+@check(
+    id="com.google.fonts/check/arabic_spacing_symbols",
+    proposal=[
+        "https://github.com/googlefonts/fontbakery/issues/4295",
+    ],
+    rationale="""
+        Unicode has a few spacing symbols representing Arabic dots and other marks,
+        but they are purposefully not classified as marks.
+
+        Many fonts mistakenly classify them as marks, making them unsuitable
+        for their original purpose as stand-alone symbols to used in pedagogical
+        contexts discussing Arabic consonantal marks.
+    """,
+    experimental="Since 2023/Oct/20",
+    severity=4,
+)
+def com_google_fonts_check_spacing_symbols(ttFont):
+    """Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks."""
+    import babelfont
+
+    # code-points
+    ARABIC_SPACING_SYMBOLS = {
+        0xFBB2,  # Dot Above
+        0xFBB3,  # Dot Below
+        0xFBB4,  # Two Dots Above
+        0xFBB5,  # Two Dots Below
+        0xFBB6,  # Three Dots Above
+        0xFBB7,  # Three Dots Below
+        0xFBB8,  # Three Dots Pointing Downwards Above
+        0xFBB9,  # Three Dots Pointing Downwards Below
+        0xFBBA,  # Four Dots Above
+        0xFBBB,  # Four Dots Below
+        0xFBBC,  # Double Vertical Bar Below
+        0xFBBD,  # Two Dots Vertically Above
+        0xFBBE,  # Two Dots Vertically Below
+        0xFBBF,  # Ring
+        0xFBC0,  # Small Tah Above
+        0xFBC1,  # Small Tah Below
+    }
+
+    passed = True
+    font = babelfont.load(ttFont.reader.file.name)
+
+    if "GDEF" in ttFont:
+        class_def = ttFont["GDEF"].table.GlyphClassDef.classDefs
+        for glyph in font.glyphs:
+            if set(glyph.codepoints).intersection(ARABIC_SPACING_SYMBOLS):
+                if glyph.name in class_def and class_def[glyph.name] == 3:
+                    passed = False
+                    yield FAIL, Message(
+                        "mark-in-gdef",
+                        f'"{glyph.name}" is defined in GDEF as a mark (class 3).',
                     )
 
     if passed:


### PR DESCRIPTION
Unicode has a few spacing symbols (U+FBB2–FBC1) representing Arabic dots and other marks, but they are purposefully not classified as marks.

Many fonts mistakenly classify them as marks, making them unsuitable for their original purpose as stand-alone symbols to used in pedagogical contexts discussing Arabic consonantal marks.

Added to the Universal Profile
**com.google.fonts/check/arabic_spacing_symbols** (experimental)
(issue #4295)