### PR TITLE
New check: Arabic letter high hamza isn't classified as a mark.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
 #### Added to the Universal Profile
   - **EXPERIMENTAL - [com.google.fonts/check/arabic_spacing_symbols]:** Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks. (issue #4295)
+  - **EXPERIMENTAL - [com.google.fonts/check/arabic_high_hamza]:** Check that glyph for U+0675 ARABIC LETTER HIGH HAMZA is not a mark. (issue #4290)
 
 ### Changes to existing checks
 #### On the Universal Profile


### PR DESCRIPTION
Many fonts incorrectly treat ARABIC LETTER HIGH HAMZA (U+0675) as a variant of ARABIC HAMZA ABOVE (U+0654) and make it a combining mark of the same size.

But U+0675 is a base letter and should be a variant of ARABIC LETTER HAMZA (U+0621) but raised slightly above baseline.

Not doing so effectively makes the font useless for Jawi and possibly Kazakh as well.

Added to the Universal Profile
**com.google.fonts/check/arabic_high_hamza** (experimental) (issue #4290)