### PR TITLE
Fix check/metadata/consistent_repo_urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Google Fonts Profile
   - **EXPERIMENTAL - [com.google.fonts/check/glyphsets/shape_languages]:** This check uses a heuristic to determine which GF glyphsets a font supports. Then it checks the font for correct shaping behaviour for all languages in those glyphsets. (issue #4147)
 
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/consistent_repo_urls]:** Git URLs can contain dashes and also there may be multiple URLs in a single description file. (issue #4316)
+
 
 ## 0.10.2 (2023-Oct-20)
 ### New checks

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3350,7 +3350,7 @@ def com_google_fonts_check_metadata_consistent_repo_urls(
 
     import re
 
-    A_GITHUB_URL = r"github.com/\w+/\w+"
+    A_GITHUB_URL = r"github.com/[\w-]+/[\w-]+"
 
     def clean_url(url):
         if ")" in url:
@@ -3384,7 +3384,7 @@ def com_google_fonts_check_metadata_consistent_repo_urls(
 
     if a_url and description:
         headless = re.sub(r"^https?://", "", a_url)
-        for match in re.findall(A_GITHUB_URL, description):
+        for match in set(re.findall(A_GITHUB_URL, description)):
             if clean_url(match) != headless:
                 bad_urls.append(("HTML description", match))
 


### PR DESCRIPTION
Git URLs can contain dashes and also there may be multiple URLs in a single description file.
**com.google.fonts/check/metadata/consistent_repo_urls**
On the Google Fonts Profile

(issue #4316)