### PR TITLE
Accept escaped quotes on check/metadata/escaped_strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.10.4 (2023-Nov-??)
-  - ...
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/escaped_strings]:** Accept escaped quotes. They're fine. This check is really meant to detect things like "Juli\303\241n" instead of "Julián". (issue #4331)
 
 
 ## Upcoming release: 0.10.3 (2023-Nov-02)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -6808,8 +6808,12 @@ def com_google_fonts_check_STAT_axis_order(fonts):
     id="com.google.fonts/check/metadata/escaped_strings",
     rationale="""
         In some cases we've seen designer names and other fields with escaped strings
-        in METADATA files. Nowadays the strings can be full unicode strings and
-        do not need escaping.
+        in METADATA files (such as "Juli\\303\\241n").
+
+        Nowadays the strings can be full unicode strings (such as "Julián") and do
+        not need escaping.
+
+        Escaping quotes or double-quotes is fine, though.
     """,
     conditions=["metadata_file"],
     proposal="https://github.com/fonttools/fontbakery/issues/2932",
@@ -6818,6 +6822,12 @@ def com_google_fonts_check_metadata_escaped_strings(metadata_file):
     """Ensure METADATA.pb does not use escaped strings."""
     passed = True
     for line in open(metadata_file, "r", encoding="utf-8").readlines():
+        # Escaped quotes are fine!
+        # What we're really interested in detecting things like
+        # "Juli\303\241n" instead of "Julián"
+        line = line.replace("\\'", "")
+        line = line.replace('\\"', "")
+
         for quote_char in ["'", '"']:
             segments = line.split(quote_char)
             if len(segments) >= 3:


### PR DESCRIPTION
The escaped quotes are fine. This check is really meant to detect things like "Juli\303\241n" instead of "Julián".

com.google.fonts/check/metadata/escaped_strings
On the Google Fonts Profile
(issue #4331)