### PR TITLE
Updating the RFN exception list

### DIFF
--- a/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
@@ -8,26 +8,11 @@
 # still needs to be more carefully reviewed.
 # See https://github.com/fonttools/fontbakery/issues/3612
 
-Abyssinica SIL
 Akatab
 Alike
 Alike Angular
-Alkalami
-Andika
-Annapurna
-Charis SIL
 David Libre
-Ezra SIL
-Gentium Book Plus
-Gentium Plus
 Harmattan
 Intel One Mono
-Lateef
-Mingzat
 Narnoor
-Nuosu SIL
-Padauk
 Scheherazade New
-Shimenkan
-Tagmukay
-Tai Heritage Pro


### PR DESCRIPTION
## Description
This issue updates the RFN exception list by deleting the font families for one of the following reasons:
- The font family no longer has an RFN in the Metadata
    - Abyssinica SIL
    - Abyssinica SIL
    - Alkalami
    - Andika
    - Charis SIL
    - Gentium Book Plus
    - Gentium Plus
    - Lateef
    - Mingzat
    - Nuosu SIL
    - Tai Heritage Pro

- The font is no longer included in the Catalog
    - Annapurna
    - Ezra SIL
    - Padauk
    - Shimenkan 

cc @RosaWagner 

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

