### PR TITLE
Bring back the RFN exceptions deleted earlier this week

### DIFF
--- a/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
@@ -8,11 +8,21 @@
 # still needs to be more carefully reviewed.
 # See https://github.com/fonttools/fontbakery/issues/3612
 
+Abyssinica SIL
 Akatab
 Alike
 Alike Angular
+Alkalami
+Andika
+Charis SIL
 David Libre
+Gentium Book Plus
+Gentium Plus
 Harmattan
 Intel One Mono
+Lateef
+Mingzat
 Narnoor
+Nuosu SIL
 Scheherazade New
+Tai Heritage Pro


### PR DESCRIPTION
According to the conversation at:
https://github.com/fonttools/fontbakery/pull/4333#issuecomment-1812475014