### PR TITLE
check/arabic_spacing_symbols - remove experimental status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.10.5 (2023-Nov-??)
-  - ...
+### Changes to existing checks
+#### On the Universal Profile
+  - **[com.google.fonts/check/arabic_spacing_symbols]**: "Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks." Originally implemented in v0.10.2 / **No longer marked as experimental.** (issue #4295)
 
 
 ## 0.10.4 (2023-Nov-17)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -775,7 +775,6 @@ def com_google_fonts_check_legacy_accents(ttFont):
         for their original purpose as stand-alone symbols to used in pedagogical
         contexts discussing Arabic consonantal marks.
     """,
-    experimental="Since 2023/Oct/20",
     severity=4,
 )
 def com_google_fonts_check_arabic_spacing_symbols(ttFont):


### PR DESCRIPTION
* Originally implemented in v0.10.2, **No longer marked as experimental.**
* On the Universal Profile: **com.google.fonts/check/arabic_spacing_symbols**
* `"Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks."`
* (issue #4295)