### PR TITLE
Improvements to check/version_bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.10.5 (2023-Nov-??)
 ### Changes to existing checks
 #### On the Universal Profile
-  - **[com.google.fonts/check/arabic_spacing_symbols]**: "Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks." Originally implemented in v0.10.2 / **No longer marked as experimental.** (issue #4295)
+  - **[com.google.fonts/check/arabic_spacing_symbols]:** "Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks." Originally implemented in v0.10.2 / **No longer marked as experimental.** (issue #4295)
+
+#### On the Google Fonts Profile
+  - **[@condition github_gfonts_ttFont]:** Fixed a bug that was not properly handling the square brackets used in variable font file names. (issue #4340)
+  - **[com.google.fonts/check/version_bump]:** Improved log messages making them more legible and also fixing the formating of the version numbers (issue #4340)
 
 
 ## 0.10.4 (2023-Nov-17)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3974,35 +3974,36 @@ def com_google_fonts_check_version_bump(
     if v_number == api_gfonts_v_number:
         passed = False
         yield FAIL, (
-            f"Version number {v_number} is equal to" f" version on Google Fonts."
+            f"Version number {v_number:0.3f} is"
+            f" equal to version on **Google Fonts**."
         )
 
     if v_number < api_gfonts_v_number:
         passed = False
         yield FAIL, (
-            f"Version number {v_number} is less than"
-            f" version on Google Fonts ({api_gfonts_v_number})."
+            f"Version number {v_number:0.3f} is less than on"
+            f" **Google Fonts** ({api_gfonts_v_number:0.3f})."
         )
 
     if v_number == github_gfonts_v_number:
         passed = False
         yield FAIL, (
-            f"Version number {v_number} is equal to"
-            f" version on Google Fonts GitHub repo."
+            f"Version number {v_number:0.3f} is equal to version on"
+            f" google/fonts **GitHub repo**."
         )
 
     if v_number < github_gfonts_v_number:
         passed = False
         yield FAIL, (
-            f"Version number {v_number} is less than"
-            f" version on Google Fonts GitHub repo ({github_gfonts_v_number})."
+            f"Version number {v_number:0.3f} is less than on"
+            f" google/fonts **GitHub repo** ({github_gfonts_v_number:0.3f})."
         )
 
     if passed:
         yield PASS, (
-            f"Version number {v_number} is greater than"
-            f" version on Google Fonts GitHub ({github_gfonts_v_number})"
-            f" and production servers ({api_gfonts_v_number})."
+            f"Version number {v_number:0.3f} is greater than on"
+            f" google/fonts **GitHub repo** ({github_gfonts_v_number:0.3f})"
+            f" and **production servers** ({api_gfonts_v_number:0.3f})."
         )
 
 

--- a/Lib/fontbakery/profiles/googlefonts_conditions.py
+++ b/Lib/fontbakery/profiles/googlefonts_conditions.py
@@ -578,7 +578,7 @@ def github_gfonts_ttFont(ttFont, license_filename):
 
     LICENSE_DIRECTORY = {"OFL.txt": "ofl", "UFL.txt": "ufl", "LICENSE.txt": "apache"}
     filename = os.path.basename(ttFont.reader.file.name)
-    familyname = filename.split("-")[0].lower()
+    familyname = filename.split("-")[0].split("[")[0].lower()
     url = (
         f"https://github.com/google/fonts/raw/main"
         f"/{LICENSE_DIRECTORY[license_filename]}/{familyname}/{filename}"


### PR DESCRIPTION
Improved log messages making them more legible and also fixing the formating of the version numbers.

Also fixed a bug in `@condition github_gfonts_ttFont` that was not properly handling the square brackets used in variable font file names.

**com.google.fonts/check/version_bump**
On the Google Fonts profile.
(issue #4340)