### PR TITLE
check/postscript_name: render markdown table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
  - Serialize a check's documentation along with the other properties so reports can get at it.
 
 ### Changes to existing checks
+#### On the Open Type Profile
+  - **[com.adobe.fonts/check/postscript_name]:** Render GitHub Flavoured Markdown on HTML reporter output, so that we can have nice things like tables. (issue #4346)
+
 #### On the Universal Profile
   - **[com.google.fonts/check/arabic_spacing_symbols]:** "Check that Arabic spacing symbols U+FBB2–FBC1 aren't classified as marks." Originally implemented in v0.10.2 / **No longer marked as experimental.** (issue #4295)
 

--- a/Lib/fontbakery/profiles/name.py
+++ b/Lib/fontbakery/profiles/name.py
@@ -7,6 +7,7 @@ from fontbakery.constants import (
     WindowsEncodingID,
     WindowsLanguageID,
 )
+from fontbakery.utils import markdown_table
 
 # used to inform get_module_profile whether and how to create a profile
 from fontbakery.fonts_profile import profile_factory  # noqa:F401 pylint:disable=W0611
@@ -436,31 +437,30 @@ def com_adobe_fonts_check_postscript_name(ttFont):
         if bad_psname.search(string):
             bad_entries.append(
                 {
-                    "field": "PostScript Name",
-                    "value": string,
-                    "rec": ("May contain only a-zA-Z0-9 characters and a hyphen."),
+                    "Field": "PostScript Name",
+                    "Value": string,
+                    "Recommendation": (
+                        "May contain only a-zA-Z0-9 characters and a hyphen."
+                    ),
                 }
             )
         if string.count("-") > 1:
             bad_entries.append(
                 {
-                    "field": "Postscript Name",
-                    "value": string,
-                    "rec": ("May contain not more than a single hyphen."),
+                    "Field": "Postscript Name",
+                    "Value": string,
+                    "Recommendation": ("May contain not more than a single hyphen."),
                 }
             )
 
     if len(bad_entries) > 0:
-        table = "| Field | Value | Recommendation |\n"
-        table += "|:----- |:----- |:-------------- |\n"
-        for bad in bad_entries:
-            table += "| {} | {} | {} |\n".format(bad["field"], bad["value"], bad["rec"])
         yield FAIL, Message(
             "bad-psname-entries",
-            f"PostScript name does not follow requirements:\n\n{table}",
+            f"PostScript name does not follow requirements:\n\n"
+            f"{markdown_table(bad_entries)}",
         )
     else:
-        yield PASS, Message("psname-ok", "PostScript name follows requirements.")
+        yield PASS, "PostScript name follows requirements."
 
 
 @check(

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -282,7 +282,7 @@ class HTMLReporter(SerializeReporter):
         if self.succinct or "rationale" not in check:
             return ""
         content = unindent_and_unwrap_rationale(check["rationale"], checkid)
-        return cmarkgfm.markdown_to_html(
+        return cmarkgfm.github_flavored_markdown_to_html(
             content, options=cmarkgfmOptions.CMARK_OPT_UNSAFE
         )
 
@@ -292,7 +292,7 @@ class HTMLReporter(SerializeReporter):
         if not self.omit_loglevel(log["status"]):
             emoticon = EMOTICON[log["status"]]
             status = log["status"]
-            message = cmarkgfm.markdown_to_html(
+            message = cmarkgfm.github_flavored_markdown_to_html(
                 log["message"], options=cmarkgfmOptions.CMARK_OPT_UNSAFE
             )
             return (

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -665,7 +665,7 @@ def test_check_name_postscript():
 
     # Test a font that has OK psname. Check should PASS.
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
-    assert_PASS(check(ttFont), "psname-ok")
+    assert_PASS(check(ttFont))
 
     # Change the PostScript name string to more than one hyphen. Should FAIL.
     bad_ps_name = "more-than-one-hyphen".encode("utf-16-be")


### PR DESCRIPTION
Render GitHub Flavoured Markdown on HTML reporter output, so that we can have nice things like tables.

com.adobe.fonts/check/postscript_name
On the Open Type Profile

and any other check that prints out markdown tables
(issue #4346)