### PR TITLE
Fix check/interpolation_issues crash with newer fonttools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 
 #### On the Universal Profile
-  - **[com.google.fonts/check/interpolation_issues]:** Fix crash when using fonttools>=4.46.0, and missing location formatting for contour order issues  (issue #4356)
+  - **[com.google.fonts/check/interpolation_issues]:** Fix crash when using fonttools>=4.46.0, crash when only ignored issues were found, and missing location formatting for contour order issues. (issue #4356)
 
 
 ## 0.10.6 (2023-Dec-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.10.7 (2023-Dec-??)
   - ...
 
+### Changes to existing checks
+
+#### On the Universal Profile
+  - **[com.google.fonts/check/interpolation_issues]:** Fix crash when using fonttools>=4.46.0, and missing location formatting for contour order issues  (issue #4356)
+
 
 ## 0.10.6 (2023-Dec-01)
 ### Note-worthy code changes

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -2057,7 +2057,7 @@ def com_google_fonts_check_whitespace_widths(ttFont):
     """,
     proposal="https://github.com/fonttools/fontbakery/issues/3930",
 )
-def com_google_fonts_check_iterpolation_issues(ttFont, config):
+def com_google_fonts_check_interpolation_issues(ttFont, config):
     """Detect any interpolation issues in the font."""
     from fontTools.varLib.interpolatable import test as interpolation_test
     from fontTools.varLib.models import piecewiseLinearMap

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing import List
 
 from packaging.version import VERSION_PATTERN
 
@@ -2092,9 +2093,9 @@ def com_google_fonts_check_interpolation_issues(ttFont, config):
     # have differently-typed default names, and so this optional argument must
     # be provided to ensure that returned names are always strings.
     # See: https://github.com/fonttools/fontbakery/issues/4356
-    names = []
+    names: List[str] = []
     for glyphset in glyphsets:
-        full_location = []
+        full_location: List[str] = []
         for ax in ttFont["fvar"].axes:
             normalized = glyphset.location.get(ax.axisTag, 0)
             denormalized = int(piecewiseLinearMap(normalized, axis_maps[ax.axisTag]))

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -2105,27 +2105,28 @@ def com_google_fonts_check_interpolation_issues(ttFont, config):
     # Inputs are ready; run the tests.
     results = interpolation_test(glyphsets, names=names)
 
-    if not results:
+    # Most of the potential problems varLib.interpolatable finds can't
+    # exist in a built binary variable font. We focus on those which can.
+    report = []
+    for glyph, glyph_problems in results.items():
+        for p in glyph_problems:
+            if p["type"] == "contour_order":
+                report.append(
+                    f"Contour order differs in glyph '{glyph}':"
+                    f" {p['value_1']} in {p['master_1']},"
+                    f" {p['value_2']} in {p['master_2']}."
+                )
+            elif p["type"] == "wrong_start_point":
+                report.append(
+                    f"Contour {p['contour']} start point"
+                    f" differs in glyph '{glyph}' between"
+                    f" location {p['master_1']} and"
+                    f" location {p['master_2']}"
+                )
+
+    if not report:
         yield PASS, "No interpolation issues found"
     else:
-        # Most of the potential problems varLib.interpolatable finds can't
-        # exist in a built binary variable font. We focus on those which can.
-        report = []
-        for glyph, glyph_problems in results.items():
-            for p in glyph_problems:
-                if p["type"] == "contour_order":
-                    report.append(
-                        f"Contour order differs in glyph '{glyph}':"
-                        f" {p['value_1']} in {p['master_1']},"
-                        f" {p['value_2']} in {p['master_2']}."
-                    )
-                elif p["type"] == "wrong_start_point":
-                    report.append(
-                        f"Contour {p['contour']} start point"
-                        f" differs in glyph '{glyph}' between"
-                        f" location {p['master_1']} and"
-                        f" location {p['master_2']}"
-                    )
         yield WARN, Message(
             "interpolation-issues",
             f"Interpolation issues were found in the font:\n\n"


### PR DESCRIPTION
## Description

Closes #4356.

This PR fixes com.google.fonts/check/interpolation_issues crashing with newer versions of fonttools (4.46.0+), as well as the location formatting of 'contour_order' issues, which were previously unserialised. 

The original issue suggests circumventing the default names returned by the interpolation tester, either by:

1. Providing a list of always-string names for the interpolation tester to use in place of the defaults; or
2. Using the returned indices as the main identifiers, to circumvent string names entirely.

In the end this PR attempts (1), as (2) would only support fonttools 4.45.1+, while the version pinned in fontbakery's setup is 4.39.0+ at this time.

Aside from the fix I have resisted the urge to tinker, although this PR also fixes a small typo and adds a wee bit of typing for peace of mind : )

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

