### PR TITLE
Don't wrap exceptions while testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.10.9 (2024-Jan-??)
   - New command-line flag `--skip-network` to skip any checks which require Internet access.
   - Fix number of log level stats colums displayed with --ghmarkdown
+  - Code tests no longer catch exceptions and instead display backtraces.
 
 
 ## 0.10.8 (2023-Dec-15)

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import types
+
 import defcon
 
 from fontbakery.checkrunner import CheckRunner
@@ -191,7 +193,10 @@ class CheckTester:
                     for varname in self.check.configs
                 }
                 self.check.inject_globals(new_globals)
-            return list(self.check(**self._args))
+            result = self.check(**self._args)
+            if not isinstance(result, types.GeneratorType):
+                result = [result]
+            return list(result)
 
 
 def portable_path(p):

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -184,7 +184,14 @@ class CheckTester:
             status, msg_str = skipped
             return [(status, Message("unfulfilled-conditions", msg_str))]
         else:
-            return list(self.runner._exec_check(self.check, self._args))
+            # No "try" while testing, we want to know about exceptions
+            if self.check.configs:
+                new_globals = {
+                    varname: self.runner.config.get(self.check.id, {}).get(varname)
+                    for varname in self.check.configs
+                }
+                self.check.inject_globals(new_globals)
+            return list(self.check(**self._args))
 
 
 def portable_path(p):

--- a/Lib/fontbakery/profiles/iso15008.py
+++ b/Lib/fontbakery/profiles/iso15008.py
@@ -113,6 +113,7 @@ def com_google_fonts_check_iso15008_proportions(ttFont):
             "There was no 'H' glyph in the font,"
             " so the proportions could not be tested",
         )
+        return
 
     pen = BoundsPen(glyphset)
     glyphset["H"].draw(pen)

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -450,11 +450,14 @@ def test_check_mandatory_glyphs():
     assert message == "Font should contain the '.notdef' glyph."
 
     # Change the glyph name from 'n' to '.notdef'
+    # (Must reload the font here since we already decompiled the glyf table)
+    ttFont = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
     ttFont.glyphOrder = ["m", ".notdef"]
     for subtable in ttFont["cmap"].tables:
         if subtable.isUnicode():
             subtable.cmap[110] = ".notdef"
-
+            if 0 in subtable.cmap:
+                del subtable.cmap[0]
     results = check(ttFont)
     message = assert_results_contain([results[0]], WARN, "notdef-not-first")
     assert message == "The '.notdef' should be the font's first glyph."


### PR DESCRIPTION
## Description

Currently when I am testing the codebase, any exceptions are wrapped in ERRORs, which means the test results look like this:

```
Lib/fontbakery/codetesting.py:222: AssertionError
----------------------------- Captured stdout call -----------------------------
Test PASS with a good font...
=========================== short test summary info ============================
FAILED tests/profiles/googlefonts_test.py::test_check_shape_languages - AssertionError
====================== 1 failed, 232 deselected in 0.38s =======================
```

This is not a helpful developer experience.

If I look further up I can see that `check_results = [(<Status ERROR>, FailedCheckError("Failed with ModuleNotFoundError: No module named 'shaperglot'"))]`. In this case, that's kind of easy to understand, but when it's a more complex problem, I want to be able to see the backtrace and work out where the problem came from so I can actually fix the error.

This PR calls the check directly instead of `_exec_check`, so that the call is not wrapped in the `try` block, and the test results instead look like this:

```
    def com_google_fonts_check_glyphsets_shape_languages(ttFont, config):
        """Shapes languages in all GF glyphsets."""
>       from shaperglot.checker import Checker
E       ModuleNotFoundError: No module named 'shaperglot'

Lib/fontbakery/profiles/googlefonts.py:3478: ModuleNotFoundError
=========================== short test summary info ============================
FAILED tests/profiles/googlefonts_test.py::test_check_shape_languages - ModuleNotFoundError: No module named 'shaperglot'
====================== 1 failed, 232 deselected in 0.45s =======================
```

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

