### PR TITLE
Updated TN Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ A more detailed list of changes is available in the corresponding milestones for
   - New command-line flag `--skip-network` to skip any checks which require Internet access.
   - Fix number of log level stats colums displayed with --ghmarkdown
 
+### New checks
+#### Added to the Universal Profile
+  - **[com.typenetwork/check/varfont/ital_range]:** Check variable font ital axis has correct range.
+
+### Changes to existing checks
+#### On the TypeNework Profile
+- Improved writing of some rationales.
+- Update including latest universal checks.
 
 ## 0.10.8 (2023-Dec-15)
   - New status result: "FATAL". To be used when a problem detected is extremely bad and must be imediately addressed. (issue #4374 / Discussion #4364)

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -312,6 +312,36 @@ def com_google_fonts_check_varfont_slnt_range(ttFont, slnt_axis):
 
 
 @check(
+    id="com.typenetwork/check/varfont/ital_range",
+    rationale="""
+        The OpenType spec says at
+        https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_ital
+        that:
+
+        [...] Valid numeric range: Values must be in the range 0 to 1.
+
+    """,
+    conditions=["is_variable_font", "has_ital_axis"],
+)
+def com_typenetwork_check_varfont_ital_range(ttFont, ital_axis):
+    """The variable font 'ital' (Italic) axis coordinates
+    is in a valid range?"""
+
+    if ital_axis.minValue == 0 and ital_axis.maxValue == 1:
+        yield PASS, "Looks good!"
+    else:
+        yield FAIL, Message(
+            "invalid-ital-range",
+            f'The range of values for the "ital" axis in'
+            f" this font is {ital_axis.minValue} to {ital_axis.maxValue}."
+            f" Italic axis range must be 0 to 1, "
+            f" where Roman is 0 and Italic 1."
+            f" If you prefer a bigger variation range consider using"
+            f' "Slant" axis instead of "Italic".',
+        )
+
+
+@check(
     id="com.adobe.fonts/check/varfont/valid_axis_nameid",
     rationale="""
         According to the 'fvar' documentation in OpenType spec v1.9

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -48,6 +48,7 @@ OPENTYPE_PROFILE_CHECKS = [
     "com.google.fonts/check/varfont/regular_opsz_coord",
     "com.google.fonts/check/varfont/bold_wght_coord",
     "com.google.fonts/check/varfont/slnt_range",
+    "com.typenetwork/check/varfont/ital_range",
     "com.google.fonts/check/varfont/wght_valid_range",
     "com.google.fonts/check/varfont/wdth_valid_range",
     "com.google.fonts/check/varfont/stat_axis_record_for_each_axis",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -60,7 +60,6 @@ SET_EXPLICIT_CHECKS = {
     "com.typenetwork/check/varfont/axes_have_variation",
     "com.typenetwork/check/varfont/fvar_axes_order",
     "com.typenetwork/check/family/duplicated_names",
-    "com.typenetwork/check/family/duplicated_names",
     "com.typenetwork/check/varfont/ital_range",
     #
     # =======================================

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -60,7 +60,6 @@ SET_EXPLICIT_CHECKS = {
     "com.typenetwork/check/varfont/axes_have_variation",
     "com.typenetwork/check/varfont/fvar_axes_order",
     "com.typenetwork/check/family/duplicated_names",
-    "com.typenetwork/check/varfont/ital_range",
     #
     # =======================================
     # From adobefonts.py
@@ -107,6 +106,7 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/varfont/wght_valid_range",
     "com.google.fonts/check/varfont/wdth_valid_range",
     "com.google.fonts/check/varfont/slnt_range",
+    "com.typenetwork/check/varfont/ital_range",
     "com.adobe.fonts/check/varfont/valid_axis_nameid",
     "com.adobe.fonts/check/varfont/valid_subfamily_nameid",
     "com.adobe.fonts/check/varfont/valid_postscript_nameid",
@@ -317,7 +317,6 @@ CHECKS_IN_THIS_FILE = [
     "com.typenetwork/check/varfont/axes_have_variation",
     "com.typenetwork/check/varfont/fvar_axes_order",
     "com.typenetwork/check/family/duplicated_names",
-    "com.typenetwork/check/varfont/ital_range",
 ]
 
 SET_IMPORTED_CHECKS = set(
@@ -1725,36 +1724,6 @@ def com_typenetwork_check_family_duplicated_names(ttFonts):
 
     if not duplicate_fullNames and not duplicate_postscriptNames:
         yield PASS, "All names are unique"
-
-
-@check(
-    id="com.typenetwork/check/varfont/ital_range",
-    rationale="""
-        The OpenType spec says at
-        https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_ital
-        that:
-
-        [...] Valid numeric range: Values must be in the range 0 to 1.
-
-    """,
-    conditions=["is_variable_font", "has_ital_axis"],
-)
-def com_typenetwork_check_varfont_ital_range(ttFont, ital_axis):
-    """The variable font 'ital' (Italic) axis coordinates
-    is in a valid range?"""
-
-    if ital_axis.minValue == 0 and ital_axis.maxValue == 1:
-        yield PASS, "Looks good!"
-    else:
-        yield FAIL, Message(
-            "invalidd-ital-range",
-            f'The range of values for the "ital" axis in'
-            f" this font is {ital_axis.minValue} to {ital_axis.maxValue}."
-            f" Italic axis range must be 0 to 1, "
-            f" where Roman is 0 and Italic 1."
-            f" If you prefer a bigger variation range consider using"
-            f' "Slant" axis instead of "Italic".',
-        )
 
 
 profile.auto_register(

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -60,12 +60,13 @@ SET_EXPLICIT_CHECKS = {
     "com.typenetwork/check/varfont/axes_have_variation",
     "com.typenetwork/check/varfont/fvar_axes_order",
     "com.typenetwork/check/family/duplicated_names",
+    "com.typenetwork/check/family/duplicated_names",
+    "com.typenetwork/check/varfont/ital_range",
     #
     # =======================================
     # From adobefonts.py
     "com.adobe.fonts/check/family/consistent_upm",
-    # 'com.adobe.fonts/check/find_empty_letters', # Temporarily disabled,
-    #                                             # the check is broken
+    # "com.adobe.fonts/check/find_empty_letters", # The check is broken
     "com.adobe.fonts/check/nameid_1_win_english",
     "com.adobe.fonts/check/unsupported_tables",
     "com.adobe.fonts/check/STAT_strings",
@@ -91,7 +92,7 @@ SET_EXPLICIT_CHECKS = {
     # =======================================
     # From fontwerk.py
     "com.fontwerk/check/no_mac_entries",
-    # 'com.fontwerk/check/vendor_id', # PERMANENTLY EXCLUDED
+    # "com.fontwerk/check/vendor_id", # PERMANENTLY EXCLUDED
     "com.fontwerk/check/weight_class_fvar",
     "com.fontwerk/check/inconsistencies_between_fvar_stat",
     "com.fontwerk/check/style_linking",
@@ -129,11 +130,13 @@ SET_EXPLICIT_CHECKS = {
     #
     # =======================================
     # From googlefonts.py
+    "com.google.fonts/check/family/equal_codepoint_coverage",
     "com.google.fonts/check/vendor_id",
-    # 'com.google.fonts/check/metadata/unreachable_subsetting', # Review
-    # 'com.google.fonts/check/gasp', # Review
-    # 'com.google.fonts/check/metadata/valid_nameid25', # TEMPORARY EXCLUDED
-    # 'com.google.fonts/check/metadata/primary_script', # Review
+    # "com.google.fonts/check/metadata/unreachable_subsetting", # Review
+    # "com.google.fonts/check/gasp", # Review
+    # "com.google.fonts/check/metadata/valid_nameid25", # TEMPORARY EXCLUDED
+    # "com.google.fonts/check/metadata/primary_script", # Review
+    # "com.google.fonts/check/glyphsets/shape_languages", # Review
     "com.google.fonts/check/slant_direction",
     "com.google.fonts/check/negative_advance_width",
     "com.google.fonts/check/glyf_nested_components",
@@ -147,13 +150,14 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/name/family_and_style_max_length",
     "com.google.fonts/check/family/control_chars",
     "com.google.fonts/check/varfont_duplicate_instance_names",
-    # 'com.google.fonts/check/varfont/duplexed_axis_reflow', # Review
-    # 'com.google.fonts/check/STAT/axis_order',
+    # "com.google.fonts/check/varfont/duplexed_axis_reflow", # Review
+    # "com.google.fonts/check/STAT/axis_order",
     "com.google.fonts/check/mandatory_avar_table",
     "com.google.fonts/check/missing_small_caps_glyphs",
     "com.google.fonts/check/stylisticset_description",
-    # 'com.google.fonts/check/os2/use_typo_metrics', # Removed in favor of
+    # "com.google.fonts/check/os2/use_typo_metrics", # Removed in favor of
     #                                                # new vmetrics check
+    # "com.google.fonts/check/metadata/empty_designer", # Review
     #
     # =======================================
     # From gpos.py
@@ -188,7 +192,7 @@ SET_EXPLICIT_CHECKS = {
     # =======================================
     # From name.py
     "com.adobe.fonts/check/name/empty_records",
-    # 'com.google.fonts/check/name/no_copyright_on_description', # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/name/no_copyright_on_description", # PERMANENTLY_EXCLUDED
     "com.google.fonts/check/monospace",
     "com.google.fonts/check/name/match_familyname_fullfont",  # OVERRIDEN
     "com.adobe.fonts/check/postscript_name",  # REVIEW
@@ -201,17 +205,17 @@ SET_EXPLICIT_CHECKS = {
     #
     # =======================================
     # From notofonts.py
-    # 'com.google.fonts/check/cmap/unexpected_subtables',  # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/unicode_range_bits',
-    # 'com.google.fonts/check/name/noto_manufacturer',     # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/name/noto_designer',         # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/name/noto_trademark',        # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/cmap/format_12',
-    # 'com.google.fonts/check/os2/noto_vendor',            # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/hmtx/encoded_latin_digits',  # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/hmtx/comma_period',          # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/hmtx/whitespace_advances',   # PERMANENTLY_EXCLUDED
-    # 'com.google.fonts/check/cmap/alien_codepoints',
+    # "com.google.fonts/check/cmap/unexpected_subtables", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/unicode_range_bits", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/name/noto_manufacturer", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/name/noto_designer", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/name/noto_trademark", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/cmap/format_12", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/os2/noto_vendor", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/hmtx/encoded_latin_digits", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/hmtx/comma_period", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/hmtx/whitespace_advances", # PERMANENTLY_EXCLUDED
+    # "com.google.fonts/check/cmap/alien_codepoints", # PERMANENTLY_EXCLUDED
     #
     # =======================================
     # From os2.py
@@ -221,7 +225,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/fsselection_matches_macstyle",
     "com.adobe.fonts/check/family/bold_italic_unique_for_nameid1",
     "com.google.fonts/check/code_pages",
-    # 'com.thetypefounders/check/vendor_id', # PERMANENTLY_EXCLUDED
+    # "com.thetypefounders/check/vendor_id", # PERMANENTLY_EXCLUDED
     "com.google.fonts/check/fsselection",
     #
     # =======================================
@@ -240,9 +244,9 @@ SET_EXPLICIT_CHECKS = {
     #
     # =======================================
     # From shaping.py
-    # 'com.google.fonts/check/shaping/regression',
-    # 'com.google.fonts/check/shaping/forbidden',
-    # 'com.google.fonts/check/shaping/collides',
+    # "com.google.fonts/check/shaping/regression",
+    # "com.google.fonts/check/shaping/forbidden",
+    # "com.google.fonts/check/shaping/collides",
     "com.google.fonts/check/dotted_circle",  # REVIEW
     "com.google.fonts/check/soft_dotted",  # REVIEW
     #
@@ -258,16 +262,19 @@ SET_EXPLICIT_CHECKS = {
     # From universal.py
     "com.google.fonts/check/name/trailing_spaces",
     "com.google.fonts/check/family/win_ascent_and_descent",
-    # 'com.google.fonts/check/os2_metrics_match_hhea', # Removed in favor of
+    # "com.google.fonts/check/os2_metrics_match_hhea", # Removed in favor of
     #                                                  # new vmetrics check
     "com.google.fonts/check/family/single_directory",
-    # 'com.google.fonts/check/caps_vertically_centered', # REVIEW
+    # "com.google.fonts/check/caps_vertically_centered", # REVIEW
     "com.google.fonts/check/ots",  # OVERRIDEN
-    # 'com.google.fonts/check/fontbakery_version', # Permanently Removed
+    # "com.google.fonts/check/fontbakery_version", # Permanently Removed
     "com.google.fonts/check/mandatory_glyphs",
     "com.google.fonts/check/whitespace_glyphs",
     "com.google.fonts/check/whitespace_glyphnames",
     "com.google.fonts/check/whitespace_ink",
+    'com.google.fonts/check/legacy_accents',
+    'com.google.fonts/check/arabic_spacing_symbols',
+    'com.google.fonts/check/arabic_high_hamza',
     "com.google.fonts/check/required_tables",
     "com.google.fonts/check/unwanted_tables",
     "com.google.fonts/check/STAT_strings",
@@ -291,7 +298,7 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/math_signs_width",  # OVERRIDEN
     "com.google.fonts/check/linegaps",
     "com.google.fonts/check/STAT_in_statics",
-    "com.google.fonts/check/alt_caron",  # REVIEW
+    # "com.google.fonts/check/alt_caron",  # PERMANENTLY EXCLUDED
 }
 
 CHECKS_IN_THIS_FILE = [
@@ -311,6 +318,7 @@ CHECKS_IN_THIS_FILE = [
     "com.typenetwork/check/varfont/axes_have_variation",
     "com.typenetwork/check/varfont/fvar_axes_order",
     "com.typenetwork/check/family/duplicated_names",
+    "com.typenetwork/check/varfont/ital_range",
 ]
 
 SET_IMPORTED_CHECKS = set(
@@ -460,7 +468,7 @@ def com_typenetwork_glyph_coverage(ttFont, font_codepoints, config):
         0x007C: ("|", "VERTICAL LINE"),
         0x007D: ("}", "RIGHT CURLY BRACKET"),
         0x007E: ("~", "TILDE"),
-        0x00A0: (" ", "NO-BREAK SPACE"),
+        0x00A0: (" ", "NO-BREAK SPACE"),
         0x00A1: ("¡", "INVERTED EXCLAMATION MARK"),
         0x00A2: ("¢", "CENT SIGN"),
         0x00A3: ("£", "POUND SIGN"),
@@ -731,7 +739,7 @@ def com_typenetwork_glyph_coverage(ttFont, font_codepoints, config):
         # 0x03A9: ("Ω", "GREEK CAPITAL LETTER OMEGA"),
         # 0x03BC: ("μ", "GREEK SMALL LETTER MU"),
         # 0x03C0: ("π", "GREEK SMALL LETTER PI"),
-        # 0x2126: ("Ω", "OHM SIGN"),
+        # 0x2126: ("Ω", "OHM SIGN"),
         # 0x2202: ("∂", "PARTIAL DIFFERENTIAL"),
         # 0x2206: ("∆", "INCREMENT"),
         # 0x220F: ("∏", "N-ARY PRODUCT"),
@@ -892,26 +900,26 @@ def com_typenetwork_check_font_is_centered_vertically(ttFont):
     if threshold1 >= ratio > threshold2:
         yield WARN, Message(
             "uncentered",
-            "The font will be displayed a bit vertically uncentered on"
+            "The font will display slightly vertically uncentered on"
             " web environments.",
         )
         yield WARN, Message(
             "uncentered",
-            f"The font will be displayed a bit vertically uncentered on"
+            f"The font will display vertically uncentered on"
             f" web environments. Top space above cap height is {ascent}"
             f" and under baseline is {descent}",
         )
     elif ratio >= threshold2:
         yield FAIL, Message(
             "very-uncentered",
-            f"The font will be displayed really vertically uncentered on"
+            f"The font will display significantly vertically uncentered on"
             f" web environments. Top space above cap height is {ascent}"
             f" and under baseline is {descent}",
         )
     else:
         yield PASS, Message(
             "centered",
-            "The font will be displayed vertically centered on web environments.",
+            "The font will display vertically centered on web environments.",
         )
 
 
@@ -1025,6 +1033,11 @@ def com_typenetwork_check_usweightclass(ttFont, tn_expected_os2_weight):
     # However, if the values are incorrect we will recommend they set Thin
     # to 100 and ExtraLight to 250.
     # for static otfs, Thin must be 250 and ExtraLight must be 275
+
+    elif not expected_value:
+        failed = True
+        yield INFO, Message("no-value", no_value_message.format(os2_value, weight_name))
+
     elif "Thin" == weight_name.split(" "):
         if is_ttf(ttFont) and os2_value not in [100, 250]:
             failed = True
@@ -1045,9 +1058,9 @@ def com_typenetwork_check_usweightclass(ttFont, tn_expected_os2_weight):
             failed = True
             yield FAIL, Message("bad-value", fail_message.format(os2_value, 275))
 
-    elif not expected_value:
+    elif os2_value != expected_value:
         failed = True
-        yield INFO, Message("no-value", no_value_message.format(os2_value, weight_name))
+        yield FAIL, Message("bad-value", fail_message.format(os2_value, expected_value))
 
     if not failed:
         yield PASS, "OS/2 usWeightClass is good"
@@ -1327,7 +1340,7 @@ def com_typenetwork_check_fstype(ttFont):
 @check(
     id="com.typenetwork/check/composite_glyphs",
     rationale="""
-        For performance reasons, is desirable that TTF fonts use composites glyphs.
+        For performance reasons, it is recommended that TTF fonts use composite glyphs.
     """,
     conditions=["is_ttf"],
     proposal=["https://github.com/fonttools/fontbakery/pull/4260"],
@@ -1358,8 +1371,15 @@ def com_typenetwork_check_composite_glyphs(ttFont):
 @check(
     id="com.typenetwork/check/PUA_encoded_glyphs",
     rationale="""
-        Since the use of PUA encoded glyphs is not frequent, we want to WARN when
-        a font can be a bad use of it, like to encode small caps glyphs.
+        Using Private Use Area (PUA) encodings is not recommended. They are 
+        defined by users and are not standardized. That said, PUA are font 
+        specific so they will break if the user tries to copy/paste, 
+        search/replace, or change the font. Using PUA to encode small caps, 
+        for example, is not recommended as small caps can and should be 
+        accessible via Open Type substitution instead.
+
+        If you must encode your characters in the Private Use Area (PUA),
+        do so with great caution.
     """,
     proposal=["https://github.com/fonttools/fontbakery/pull/4260"],
 )
@@ -1706,6 +1726,35 @@ def com_typenetwork_check_family_duplicated_names(ttFonts):
 
     if not duplicate_fullNames and not duplicate_postscriptNames:
         yield PASS, "All names are unique"
+
+
+@check(
+    id="com.typenetwork/check/varfont/ital_range",
+    rationale="""
+        The OpenType spec says at
+        https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_ital that:
+
+        [...] Valid numeric range: Values must be in the range 0 to 1.
+
+    """,
+    conditions=["is_variable_font", "has_ital_axis"]
+)
+def com_typenetwork_check_varfont_ital_range(ttFont, ital_axis):
+    """The variable font 'ital' (Italic) axis coordinates
+    is in a valid range?"""
+
+    if ital_axis.minValue == 0 and ital_axis.maxValue == 1:
+        yield PASS, "Looks good!"
+    else:
+        yield FAIL, Message(
+            "invalidd-ital-range",
+            f'The range of values for the "ital" axis in'
+            f" this font is {ital_axis.minValue} to {ital_axis.maxValue}."
+            f" Italic axis range must be 0 to 1, "
+            f" where Roman is 0 and Italic 1."
+            f" If you prefer a bigger variation range consider using"
+            f' "Slant" axis instead of "Italic".'
+        )
 
 
 profile.auto_register(

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -1371,11 +1371,11 @@ def com_typenetwork_check_composite_glyphs(ttFont):
 @check(
     id="com.typenetwork/check/PUA_encoded_glyphs",
     rationale="""
-        Using Private Use Area (PUA) encodings is not recommended. They are 
-        defined by users and are not standardized. That said, PUA are font 
-        specific so they will break if the user tries to copy/paste, 
-        search/replace, or change the font. Using PUA to encode small caps, 
-        for example, is not recommended as small caps can and should be 
+        Using Private Use Area (PUA) encodings is not recommended. They are
+        defined by users and are not standardized. That said, PUA are font
+        specific so they will break if the user tries to copy/paste,
+        search/replace, or change the font. Using PUA to encode small caps,
+        for example, is not recommended as small caps can and should be
         accessible via Open Type substitution instead.
 
         If you must encode your characters in the Private Use Area (PUA),
@@ -1732,7 +1732,8 @@ def com_typenetwork_check_family_duplicated_names(ttFonts):
     id="com.typenetwork/check/varfont/ital_range",
     rationale="""
         The OpenType spec says at
-        https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_ital that:
+        https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_ital
+        that:
 
         [...] Valid numeric range: Values must be in the range 0 to 1.
 

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -272,9 +272,9 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/whitespace_glyphs",
     "com.google.fonts/check/whitespace_glyphnames",
     "com.google.fonts/check/whitespace_ink",
-    'com.google.fonts/check/legacy_accents',
-    'com.google.fonts/check/arabic_spacing_symbols',
-    'com.google.fonts/check/arabic_high_hamza',
+    "com.google.fonts/check/legacy_accents",
+    "com.google.fonts/check/arabic_spacing_symbols",
+    "com.google.fonts/check/arabic_high_hamza",
     "com.google.fonts/check/required_tables",
     "com.google.fonts/check/unwanted_tables",
     "com.google.fonts/check/STAT_strings",
@@ -1737,7 +1737,7 @@ def com_typenetwork_check_family_duplicated_names(ttFonts):
         [...] Valid numeric range: Values must be in the range 0 to 1.
 
     """,
-    conditions=["is_variable_font", "has_ital_axis"]
+    conditions=["is_variable_font", "has_ital_axis"],
 )
 def com_typenetwork_check_varfont_ital_range(ttFont, ital_axis):
     """The variable font 'ital' (Italic) axis coordinates
@@ -1753,7 +1753,7 @@ def com_typenetwork_check_varfont_ital_range(ttFont, ital_axis):
             f" Italic axis range must be 0 to 1, "
             f" where Roman is 0 and Italic 1."
             f" If you prefer a bigger variation range consider using"
-            f' "Slant" axis instead of "Italic".'
+            f' "Slant" axis instead of "Italic".',
         )
 
 


### PR DESCRIPTION
## Description
Updated Type Network profile.
Also we added a check [com.typenetwork/check/varfont/ital_range]( https://github.com/guidoferreyra/fontbakery/blob/c0363aad8ccecac12718064d96fb17fc4d452f22/Lib/fontbakery/profiles/typenetwork.py#L1731). That should belong to the universal profile, probably the code should be improved but it will be good to have a check for Ital axis valid range on the universal profile.