### PR TITLE
Allow setting font variations in shaping regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - New command-line flag `--skip-network` to skip any checks which require Internet access.
   - Fix number of log level stats colums displayed with --ghmarkdown
 
+### Changes to existing checks
+#### On the Shaping profile
+- **[com.google.fonts/check/shaping/regression]:** Font variations can now be set in the test configuration, similar to font features.
 
 ## 0.10.8 (2023-Dec-15)
   - New status result: "FATAL". To be used when a problem detected is extremely bad and must be imediately addressed. (issue #4374 / Discussion #4364)

--- a/Lib/fontbakery/profiles/shaping.py
+++ b/Lib/fontbakery/profiles/shaping.py
@@ -144,6 +144,9 @@ def get_shaping_parameters(test, configuration):
     params = {}
     for el in ["script", "language", "direction", "features", "shaper"]:
         params[el] = get_from_test_with_default(test, configuration, el)
+    params["variations"] = get_from_test_with_default(
+        test, configuration, "variations", {}
+    )
     return params
 
 
@@ -290,7 +293,7 @@ def generate_shaping_regression_report(vharfbuzz, shaping_file, failed_shaping_t
     for test, expected, output_buf, output_serialized in failed_shaping_tests:
         extra_data = {
             k: test[k]
-            for k in ["script", "language", "direction", "features"]
+            for k in ["script", "language", "direction", "features", "variations"]
             if k in test
         }
         # Make HTML report here.

--- a/tests/profiles/shaping_test.py
+++ b/tests/profiles/shaping_test.py
@@ -67,6 +67,37 @@ def test_check_shaping_regression():
         )
 
 
+def test_check_shaping_regression_with_variations():
+    """Check that we can test shaping with variation settings against expectations."""
+    check = CheckTester(shaping_profile, "com.google.fonts/check/shaping/regression")
+
+    shaping_test = {
+        "configuration": {},
+        "tests": [
+            {
+                "input": "AV",
+                "expectation": "A=0+453|V=1+505",
+            },
+            {
+                "input": "AV",
+                "expectation": "A=0+517|V=1+526",
+                "variations": {"wght": 700},
+            },
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_gf_dir:
+        json.dump(
+            shaping_test,
+            open(os.path.join(tmp_gf_dir, "test.json"), "w", encoding="utf-8"),
+        )
+
+        config = {"com.google.fonts/check/shaping": {"test_directory": tmp_gf_dir}}
+
+        font = TEST_FILE("varfont/Oswald-VF.ttf")
+        assert_PASS(check(wrap_args(config, font)), "Oswald: A=0+453|V=1+505")
+
+
 def test_check_shaping_forbidden():
     """Check that we can test for forbidden glyphs in output."""
     check = CheckTester(shaping_profile, "com.google.fonts/check/shaping/forbidden")


### PR DESCRIPTION
## Description
Vharfbuzz already supports taking font variations in the shaping parameters, so we only need to pass the variations to it.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

