### PR TITLE
fix check/metadata/valid_name_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Changes to existing checks
 #### On the Google Fonts Profile
-  - **[com.google.fonts/check/metadata/valid_name_values]:**  Compare METDATA family name against the font's best family name (issue #4262)
+  - **[com.google.fonts/check/metadata/valid_name_values]:**  Compare METADATA family name against the font's best family name (issue #4262)
 
 
 ## 0.10.8 (2023-Dec-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the OpenType profile
 - **[com.adobe.fonts/check/varfont/same_size_instance_records]:** Skip variable fonts without named instances. (issue #4410)
 
+### Changes to existing checks
+#### On the Google Fonts Profile
+  - **[com.google.fonts/check/metadata/valid_name_values]:**  Compare METDATA family name against the font's best family name (issue #4262)
+
 
 ## 0.10.8 (2023-Dec-15)
   - New status result: "FATAL". To be used when a problem detected is extremely bad and must be imediately addressed. (issue #4374 / Discussion #4364)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2585,27 +2585,20 @@ def com_google_fonts_check_metadata_match_filename_postscript(font_metadata):
 
 @check(
     id="com.google.fonts/check/metadata/valid_name_values",
-    conditions=["style", "font_metadata"],
+    conditions=["ttFont", "font_metadata"],
     proposal="legacy:check/098",
 )
-def com_google_fonts_check_metadata_valid_name_values(
-    style, font_metadata, font_familynames, typographic_familynames
-):
-    """METADATA.pb font.name field contains font name in right format?"""
-    if style in RIBBI_STYLE_NAMES:
-        familynames = font_familynames
-    else:
-        familynames = typographic_familynames
-
-    if not any((name in font_metadata.name) for name in familynames):
+def com_google_fonts_check_metadata_valid_name_values(ttFont, font_metadata):
+    """METADATA.pb font.name field matches font"""
+    family_name = ttFont["name"].getBestFamilyName()
+    if family_name != font_metadata.name:
         yield FAIL, Message(
             "mismatch",
-            f'METADATA.pb font.name field ("{font_metadata.name}")'
-            f" does not match"
-            f' correct font name format ("{", ".join(familynames)}").',
+            (f"METADATA.pb font.name field is {font_metadata.name} "
+             f"but font has {family_name}")
         )
     else:
-        yield PASS, "METADATA.pb font.name field contains font name in right format."
+        yield PASS, "METADATA.pb font.name is correct"
 
 
 @check(

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -2594,8 +2594,10 @@ def com_google_fonts_check_metadata_valid_name_values(ttFont, font_metadata):
     if family_name != font_metadata.name:
         yield FAIL, Message(
             "mismatch",
-            (f"METADATA.pb font.name field is {font_metadata.name} "
-             f"but font has {family_name}")
+            (
+                f"METADATA.pb font.name field is {font_metadata.name} "
+                f"but font has {family_name}"
+            ),
         )
     else:
         yield PASS, "METADATA.pb font.name is correct"

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2009,9 +2009,8 @@ def test_check_metadata_valid_name_values():
 
     # Good font with other language name entries
     font = TEST_FILE("bizudpmincho-nameonly/BIZUDPMincho-Regular.ttf")
-    ttfont = TTFont(font)
 
-    assert_PASS(check(ttfont), "with a good font with other languages...")
+    assert_PASS(check(font), "with a good font with other languages...")
 
 
 def test_check_metadata_valid_full_name_values():

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1986,41 +1986,32 @@ MONTSERRAT_NON_RIBBI = [
 
 
 def test_check_metadata_valid_name_values():
-    """METADATA.pb font.name field contains font name in right format?"""
+    """METADATA.pb font.name field matches font"""
     check = CheckTester(
         googlefonts_profile, "com.google.fonts/check/metadata/valid_name_values"
     )
 
     # Our reference Montserrat family is a good 18-styles family:
-    for font in MONTSERRAT_RIBBI:
+    for font in MONTSERRAT_RIBBI + MONTSERRAT_NON_RIBBI:
         # So it must PASS the check:
-        assert_PASS(check(font), f"with a good RIBBI font ({font})...")
+        ttfont = TTFont(font)
+        assert_PASS(check(ttfont), f"with a good RIBBI font ({font})...")
 
         # And fail if it finds a bad font_familyname:
+        ttfont["name"].setName("foobar", 1, 3, 1, 0x409)
+        ttfont["name"].setName("foobar", 16, 3, 1, 0x409)
         assert_results_contain(
-            check(font, {"font_familynames": ["WrongFamilyName"]}),
+            check(ttfont),
             FAIL,
             "mismatch",
             f"with a bad RIBBI font ({font})...",
         )
 
-    # We do the same for NON-RIBBI styles:
-    for font in MONTSERRAT_NON_RIBBI:
-        # So it must PASS the check:
-        assert_PASS(check(font), "with a good NON-RIBBI font ({fontfile})...")
-
-        # And fail if it finds a bad font_familyname:
-        assert_results_contain(
-            check(font, {"typographic_familynames": ["WrongFamilyName"]}),
-            FAIL,
-            "mismatch",
-            f"with a bad NON-RIBBI font ({font})...",
-        )
-
     # Good font with other language name entries
     font = TEST_FILE("bizudpmincho-nameonly/BIZUDPMincho-Regular.ttf")
+    ttfont = TTFont(font)
 
-    assert_PASS(check(font), "with a good font with other languages...")
+    assert_PASS(check(ttfont), "with a good font with other languages...")
 
 
 def test_check_metadata_valid_full_name_values():


### PR DESCRIPTION
The Google Fonts metadata checks are not up to scratch. A major reason is because the conditions to get font style info is incorrect. In https://github.com/google/fonts/pull/7100, Yanone has reported a false positive so this pr aims to fix it.

Imo we absolutely should take a sledge hammer to the metadata checks. Many seem redundant and they're just down right ugly.