### PR TITLE
Drop babelfont use in universal profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.10.10 (2024-Jan-??)
   - ...
 
+### Noteworthy code-changes
+  - babelfont dependency has been dropped.
+
 
 ## 0.10.9 (2024-Jan-12)
   - New command-line flag `--skip-network` to skip any checks which require Internet access. (PR #4387)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 --index-url https://pypi.python.org/simple/
 axisregistry==0.4.5
-babelfont==3.0.1
 beautifulsoup4==4.12.2
 beziers==0.5.0
 cmarkgfm==2022.10.27

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,6 @@ setup(
     install_requires=[
         # ---
         # core dependencies
-        "babelfont>=3.0.1",  # v3.0.1 needed by check/legacy_accents
         f"fontTools{FONTTOOLS_VERSION}",
         "freetype-py!=2.4.0",  # Avoiding 2.4.0 due to seg-fault described at
         # https://github.com/fonttools/fontbakery/issues/4143


### PR DESCRIPTION
## Description
Using babelfont here is an overkill, since we are not using any fancy features and our input is always binary fonts so we can access what we want directly from TTFont. This is also faster as babel font does a bit of loading and unparsing stuff.

(Provide a list of all the noteworthy changes you've done. Elaborate on any decisions you had to make, and include links and/or screenshots, if applicable)

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

