### PR TITLE
Update index.html CSS to fix #4370 (Error sidebar nav active state is too dark)

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
 
         .nav-pills .nav-link.active,
         .nav-pills .show>.nav-link {
-            color: inherit !important;
             background-image: linear-gradient(rgb(0 0 0/20%) 0 0);
             box-shadow: rgba(0, 0, 0, 0.15) 1.95px 1.95px 2.6px;
         }


### PR DESCRIPTION
ERROR results sidebars are dark grey on black with this

## Description
Relates to issue #4370

Before

<img width="621" alt="Screenshot 2024-01-17 at 00 28 03" src="https://github.com/fonttools/fontbakery/assets/261579/50f74709-1ae9-47b3-b7ee-362dd7749e83">

After

<img width="658" alt="Screenshot 2024-01-17 at 00 28 43" src="https://github.com/fonttools/fontbakery/assets/261579/a692caaa-329d-4b7d-b7ac-d1cada5bb2be">

Possibly you can see a better way to fix this :) 

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

