### PR TITLE
Revert legacy-accents-component overide on GFonts profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/varfont/duplexed_axis_reflow]:** yield FAILs per incorrect axis (message codes specifying axis); sort the list of bad glyphs (PR #4400)
+  - **[com.google.fonts/check/legacy_accents]:** We changed our minds here, and removed the overide to FAIL on "legacy-accents-component", so it is back a mere WARN again, just like in the Universal Profile (issue #4425)
 
 
 ## 0.10.9 (2024-Jan-12)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -44,7 +44,6 @@ OVERRIDDEN_CHECKS = [
     "com.google.fonts/check/italic_axis_in_stat_is_boolean",
     "com.google.fonts/check/italic_axis_last",
     "com.google.fonts/check/alt_caron",
-    "com.google.fonts/check/legacy_accents",
 ]
 
 METADATA_CHECKS = [
@@ -7481,13 +7480,6 @@ profile.check_log_override(
     "com.google.fonts/check/alt_caron",
     overrides=(("bad-mark", FAIL, KEEP_ORIGINAL_MESSAGE),),
     reason=("For Google Fonts, one of the comma-lookalikes is a FAIL"),
-)
-
-profile.check_log_override(
-    # From universal.py
-    "com.google.fonts/check/legacy_accents",
-    overrides=(("legacy-accents-component", FAIL, KEEP_ORIGINAL_MESSAGE),),
-    reason=("For Google Fonts, using legacy accents as components is a FAIL."),
 )
 
 GOOGLEFONTS_PROFILE_CHECKS = add_check_overrides(

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -5280,9 +5280,7 @@ def test_check_alt_caron():
 
 def test_check_legacy_accents():
     """Check that legacy accents aren't used in composite glyphs."""
-    check = CheckTester(
-        googlefonts_profile, f"com.google.fonts/check/legacy_accents{OVERRIDE_SUFFIX}"
-    )
+    check = CheckTester(googlefonts_profile, "com.google.fonts/check/legacy_accents")
 
     test_font = TTFont(TEST_FILE("montserrat/Montserrat-Regular.ttf"))
     assert_PASS(check(test_font))
@@ -5298,7 +5296,7 @@ def test_check_legacy_accents():
     test_font = TTFont(TEST_FILE("lugrasimo/Lugrasimo-Regular.ttf"))
     assert_results_contain(
         check(test_font),
-        FAIL,
+        WARN,
         "legacy-accents-component",
         "for legacy accents being used in composites.",
     )


### PR DESCRIPTION
We changed our minds here, and removed the overide to FAIL on "legacy-accents-component", so it is back a mere WARN again, just like in the Universal Profile.

**com.google.fonts/check/legacy_accents**
On the Google Fonts Profile
(issue #4425)