### PR TITLE
Terminate program when there are no pending jobs to run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## Upcoming release: 0.10.10 (2024-Jan-??)
 ### Noteworthy code-changes
-  - babelfont dependency has been dropped. (PR #4416)
-  - fix crash when no matching checks are found (issue #4420)
+  - The babelfont dependency has been dropped. (PR #4416)
+  - Fix a crash when no matching checks are found during a multi-processing run. Also, do not freeze indefinitely. Instead, terminate the program emitting a process error code -1 and giving the user some guidance. (issue #4420)
 
 ### Changes to existing checks
 #### On the Google Fonts Profile

--- a/Lib/fontbakery/multiproc.py
+++ b/Lib/fontbakery/multiproc.py
@@ -197,6 +197,16 @@ def _results_generator(results_queue, len_results):
 
 @contextmanager
 def _multiprocessing_checkrunner(jobs, process_count, *args):
+    if len(jobs) == 0:
+        import sys
+
+        print(
+            "There are no jobs to execute.\n"
+            "This looks like a corner-case like the one described at:\n"
+            "https://github.com/fonttools/fontbakery/issues/4420\n"
+        )
+        sys.exit(-1)
+
     jobs_queue = Queue()
     results_queue = Queue()
     for job in jobs:


### PR DESCRIPTION
When no matching checks are found during a multi-processing run, do not freeze indefinitely. Instead, terminate the program emitting a process error code -1 and giving the user some guidance.

(issue #4420)