### PR TITLE
Accept date ranges on check/font_copyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Google Fonts Profile
   - **[com.google.fonts/check/varfont/duplexed_axis_reflow]:** yield FAILs per incorrect axis (message codes specifying axis); sort the list of bad glyphs (PR #4400)
   - **[com.google.fonts/check/legacy_accents]:** We changed our minds here, and removed the overide to FAIL on "legacy-accents-component", so it is back a mere WARN again, just like in the Universal Profile (issue #4425)
+  - **[com.google.fonts/check/font_copyright]:** Accept date ranges. (issue #4386)
 
 
 ## 0.10.9 (2024-Jan-12)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1378,14 +1378,41 @@ def com_google_fonts_check_family_has_license(licenses, config):
         yield PASS, f"Found license at '{licenses[0]}'"
 
 
+DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING = """
+        The expected pattern for the copyright string adheres to the following rules:
+
+        * It must say "Copyright" followed by a 4 digit year (optionally followed by
+          a hyphen and another 4 digit year)
+
+        * Additional years or year ranges are also valid.
+
+        * An optional comma can be placed here.
+
+        * Then it must say "The <familyname> Project Authors" and, within parentheses,
+          a URL for a git repository must be provided. But we have an exception
+          for the fonts from the Noto project, that simply have
+          "google llc. all rights reserved" here.
+
+        * The check is case insensitive and does not validate whether the familyname
+          is correct, even though we'd obviously expect it to be.
+
+
+        Here is an example of a valid copyright string:
+
+        "Copyright 2017 The Archivo Black Project Authors
+         (https://github.com/Omnibus-Type/ArchivoBlack)"
+"""
+EXPECTED_COPYRIGHT_PATTERN = r"copyright \d{4}(-\d{4})?(,\s*\d{4}(-\d{4})?)*,? (the .* project authors \([^\@]*\)|google llc. all rights reserved)"  # noqa:E501 pylint:disable=C0301
+
+
 @check(
     id="com.google.fonts/check/license/OFL_copyright",
     conditions=["license_contents"],
     rationale="""
-        An OFL.txt file's first line should be the font copyright e.g:
-        "Copyright 2019 The Montserrat Project Authors
-        (https://github.com/julietaula/montserrat)"
-    """,
+        An OFL.txt file's first line should be the font copyright.
+
+    """
+    + DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING,
     severity=10,  # max severity because licensing mistakes can cause legal problems.
     proposal="https://github.com/fonttools/fontbakery/issues/2764",
 )
@@ -2746,32 +2773,16 @@ def com_google_fonts_check_metadata_valid_nameid25(ttFont, style):
             yield PASS, ("Name ID 25 looks good.")
 
 
-EXPECTED_COPYRIGHT_PATTERN = r"copyright [0-9]{4}(\-[0-9]{4})? (the .* project authors \([^\@]*\)|google llc. all rights reserved)"  # noqa:E501 pylint:disable=C0301
-
-
 @check(
     id="com.google.fonts/check/metadata/valid_copyright",
     conditions=["font_metadata"],
     rationale="""
-        The expected pattern for the copyright string adheres to the following rules:
+        This check aims at ensuring a uniform and legally accurate copyright statement
+        on the METADATA.pb copyright entries accross the Google Fonts library.
 
-        * It must say "Copyright" followed by a 4 digit year (optionally followed by
-          a hyphen and another 4 digit year)
-
-        * Then it must say "The <familyname> Project Authors"
-
-        * And within parentheses, a URL for a git repository must be provided
-
-        * The check is case insensitive and does not validate whether the familyname
-          is correct, even though we'd expect it is (and we may soon update the check
-          to validate that aspect as well!)
-
-
-        Here is an example of a valid copyright string:
-
-        "Copyright 2017 The Archivo Black Project Authors
-         (https://github.com/Omnibus-Type/ArchivoBlack)"
-    """,
+    """
+    + DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING,
+    severity=10,  # max severity because licensing mistakes can cause legal problems.
     proposal="legacy:check/102",
 )
 def com_google_fonts_check_metadata_valid_copyright(font_metadata):
@@ -2784,16 +2795,21 @@ def com_google_fonts_check_metadata_valid_copyright(font_metadata):
     else:
         yield FAIL, Message(
             "bad-notice-format",
-            f"METADATA.pb: Copyright notices should match"
-            f" a pattern similar to:\n"
-            f' "Copyright 2020 The Familyname Project Authors (git url)"'
-            f"\n"
-            f'But instead we have got:\n"{string}"',
+            f"METADATA.pb: Copyright notices should match a pattern similar to:\n\n"
+            f' "Copyright 2020 The Familyname Project Authors (git url)"\n\n'
+            f'But instead we have got:\n\n"{string}"',
         )
 
 
 @check(
     id="com.google.fonts/check/font_copyright",
+    rationale="""
+        This check aims at ensuring a uniform and legally accurate copyright statement
+        on the name table entries of font files accross the Google Fonts library.
+
+    """
+    + DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING,
+    severity=10,  # max severity because licensing mistakes can cause legal problems.
     proposal="https://github.com/fonttools/fontbakery/pull/2383",
 )
 def com_google_fonts_check_font_copyright(ttFont):
@@ -2813,9 +2829,9 @@ def com_google_fonts_check_font_copyright(ttFont):
             yield FAIL, Message(
                 "bad-notice-format",
                 f"Name Table entry: Copyright notices should match"
-                f' a pattern similar to: "Copyright 2019'
-                f' The Familyname Project Authors (git url)"\n'
-                f'But instead we have got:\n"{string}"',
+                f" a pattern similar to:\n\n"
+                f'"Copyright 2019 The Familyname Project Authors (git url)"\n\n'
+                f'But instead we have got:\n\n"{string}"\n',
             )
     if passed:
         yield PASS, "Name table copyright entries are good"

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2151,6 +2151,24 @@ def test_check_metadata_valid_nameid25():
     )
 
 
+# note: The copyright checks do not actually verify that the project name is correct.
+#       They only focus on the string format.
+GOOD_COPYRIGHT_NOTICE_STRINGS = (
+    (
+        "Copyright 2017 The Archivo Black Project Authors"
+        " (https://github.com/Omnibus-Type/ArchivoBlack)"
+    ),
+    (
+        "Copyright 2017-2018 The YearRange Project Authors"
+        " (https://github.com/Looks/Good)"
+    ),
+    (
+        "Copyright 2012-2014, 2016, 2019-2021, 2023 The MultiYear Project Authors"
+        " (https://github.com/With/ManyRanges)"
+    ),
+)
+
+
 def test_check_metadata_valid_copyright():
     """Copyright notice on METADATA.pb matches canonical pattern ?"""
     check = CheckTester(
@@ -2164,25 +2182,20 @@ def test_check_metadata_valid_copyright():
         check(font), FAIL, "bad-notice-format", "with a bad copyright notice string..."
     )
 
-    # Then we change it into a good string (example extracted from Archivo Black):
-    # note: the check does not actually verify that the project name is correct.
-    #       It only focuses on the string format.
-    good_string = (
-        "Copyright 2017 The Archivo Black Project Authors"
-        " (https://github.com/Omnibus-Type/ArchivoBlack)"
-    )
-    md = check["font_metadata"]
-    md.copyright = good_string
-    assert_PASS(
-        check(font, {"font_metadata": md}), "with a good copyright notice string..."
-    )
+    # Then, to make the check PASS, we change it into a few good strings:
+    for good_string in GOOD_COPYRIGHT_NOTICE_STRINGS:
+        md = check["font_metadata"]
+        md.copyright = good_string
+        assert_PASS(
+            check(font, {"font_metadata": md}), "with a good copyright notice string..."
+        )
 
-    # We also ignore case, so these should also PASS:
-    md.copyright = good_string.upper()
-    assert_PASS(check(font, {"font_metadata": md}), "with all uppercase...")
+        # We also ignore case, so these should also PASS:
+        md.copyright = good_string.upper()
+        assert_PASS(check(font, {"font_metadata": md}), "with all uppercase...")
 
-    md.copyright = good_string.lower()
-    assert_PASS(check(font, {"font_metadata": md}), "with all lowercase...")
+        md.copyright = good_string.lower()
+        assert_PASS(check(font, {"font_metadata": md}), "with all lowercase...")
 
 
 def test_check_font_copyright():
@@ -2190,7 +2203,7 @@ def test_check_font_copyright():
     check = CheckTester(googlefonts_profile, "com.google.fonts/check/font_copyright")
 
     # Our reference Cabin Regular is known to be bad
-    # Since it provides an email instead of a git URL:
+    # since it provides an email instead of a git URL:
     ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
     assert_results_contain(
         check(ttFont),
@@ -2199,17 +2212,12 @@ def test_check_font_copyright():
         "with a bad copyright notice string...",
     )
 
-    # We change it into a good string (example extracted from Archivo Black):
-    # note: the check does not actually verify that the project name is correct.
-    #       It only focuses on the string format.
-    good_string = (
-        "Copyright 2017 The Archivo Black Project Authors"
-        " (https://github.com/Omnibus-Type/ArchivoBlack)"
-    )
-    for i, entry in enumerate(ttFont["name"].names):
-        if entry.nameID == NameID.COPYRIGHT_NOTICE:
-            ttFont["name"].names[i].string = good_string.encode(entry.getEncoding())
-    assert_PASS(check(ttFont), "with good strings...")
+    # Then, to make the check PASS, we change it into a few good strings:
+    for good_string in GOOD_COPYRIGHT_NOTICE_STRINGS:
+        for i, entry in enumerate(ttFont["name"].names):
+            if entry.nameID == NameID.COPYRIGHT_NOTICE:
+                ttFont["name"].names[i].string = good_string.encode(entry.getEncoding())
+        assert_PASS(check(ttFont), "with good strings...")
 
 
 def DISABLE_test_check_glyphs_file_font_copyright():


### PR DESCRIPTION
**com.google.fonts/check/font_copyright**
On the Google Fonts profile.

Also improved wording of some log-messages and rationale text for checks related to font-copyright.
(issue #4386)