### PR TITLE
Migrate glyphsets.codepoints to gfsubsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont/duplexed_axis_reflow]:** yield FAILs per incorrect axis (message codes specifying axis); sort the list of bad glyphs (PR #4400)
   - **[com.google.fonts/check/legacy_accents]:** We changed our minds here, and removed the overide to FAIL on "legacy-accents-component", so it is back a mere WARN again, just like in the Universal Profile (issue #4425)
   - **[com.google.fonts/check/font_copyright]:** Accept date ranges. (issue #4386)
+  - **[com.google.fonts/check/metadata/unsupported_subsets]** and **[com.google.fonts/check/metadata/unreachable_subsetting]**: Updated to use the new `gfsubsets` package. (PR #4434)
+
 #### On the OpenType Profile
   - **[com.google.fonts/check/varfont/bold_wght_coord]:** Only check for a bold instance on fonts where the weight range extends to 700. (issue #4373)
   - **[com.google.fonts/check/license/OFL_body_text]:** yield WARN instead of FAIL if body text is incorrect since the Google Fonts backend will make its own license file. Also show which lines needing changing (PR #4437)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ fontTools[ufo,lxml,unicode]==4.47.2
 font-v==2.1.0
 freetype-py==2.3.0  # pinned for now. See: https://github.com/fonttools/fontbakery/issues/4143
 gflanguages==0.5.15
+gfsubsets==2024.1.22.post1
 glyphsets==0.6.11
 lxml==4.9.4  # while fonttools[lxml] still require lxml<5
 munkres==1.1.4  # This should be a dependency of fonttools instead!

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fontTools[ufo,lxml,unicode]==4.47.2
 font-v==2.1.0
 freetype-py==2.3.0  # pinned for now. See: https://github.com/fonttools/fontbakery/issues/4143
 gflanguages==0.5.15
-gfsubsets==2024.1.22.post1
+gfsubsets==2024.1.22.post2
 glyphsets==0.6.11
 lxml==4.9.4  # while fonttools[lxml] still require lxml<5
 munkres==1.1.4  # This should be a dependency of fonttools instead!

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ adobefonts_extras = []
 googlefonts_always_latest = [
     "axisregistry>=0.4.5",
     "gflanguages>=0.5.15",
+    "gfsubsets>=2024.1.22.post2",
     "glyphsets>=0.6.11",
     "shaperglot>=0.3.1",
-    "gfsubsets>=2024.1.22",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ googlefonts_always_latest = [
     "gflanguages>=0.5.15",
     "glyphsets>=0.6.11",
     "shaperglot>=0.3.1",
+    "gfsubsets>=2024.1.22",
 ]
 
 


### PR DESCRIPTION
## Description

The glyphsets library has split in two, with the subset-related code migrating to gfsubsets; this updates our code to match.

## Checklist
- [X] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

