### PR TITLE
Migration of `check/varfont/bold_wght_coord` from the `Open Type` profile to the `Google Fonts` profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - The babelfont dependency has been dropped. (PR #4416)
   - Fix a crash when no matching checks are found during a multi-processing run. Also, do not freeze indefinitely. Instead, terminate the program emitting a process error code -1 and giving the user some guidance. (issue #4420)
 
+### Migration of checks
+#### Moved to the Google Fonts profile
+  - **[com.google.fonts/check/varfont/bold_wght_coord]:** from the Open Type profile. (issue #4436)
+
 ### Changes to existing checks
 #### On the Universal Profile
   - **[com.google.fonts/check/arabic_spacing_symbols]:** Also check U+FBC2 ARABIC SYMBOL WASLA ABOVE (issue #4417)

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -66,7 +66,6 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",  # IS_OVERRIDDEN
     "com.adobe.fonts/check/varfont/valid_postscript_nameid",
     "com.adobe.fonts/check/varfont/valid_subfamily_nameid",
-    "com.google.fonts/check/varfont/bold_wght_coord",  # IS_OVERRIDDEN
     "com.google.fonts/check/varfont/regular_ital_coord",  # IS_OVERRIDDEN
     "com.google.fonts/check/varfont/regular_opsz_coord",  # IS_OVERRIDDEN
     "com.google.fonts/check/varfont/regular_slnt_coord",  # IS_OVERRIDDEN
@@ -95,6 +94,7 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/aat",
     "com.google.fonts/check/fvar_name_entries",
     "com.google.fonts/check/varfont_duplicate_instance_names",
+    "com.google.fonts/check/varfont/bold_wght_coord",  # IS_OVERRIDDEN
     #
     # =======================================
     # From gpos.py
@@ -603,7 +603,7 @@ profile.check_log_override(
 
 
 profile.check_log_override(
-    # From fvar.py
+    # From googlefonts.py
     "com.google.fonts/check/varfont/bold_wght_coord",
     overrides=(
         ("no-bold-instance", WARN, KEEP_ORIGINAL_MESSAGE),

--- a/Lib/fontbakery/profiles/fvar.py
+++ b/Lib/fontbakery/profiles/fvar.py
@@ -170,46 +170,6 @@ def com_google_fonts_check_varfont_regular_opsz_coord(ttFont, regular_opsz_coord
 
 
 @check(
-    id="com.google.fonts/check/varfont/bold_wght_coord",
-    rationale="""
-        The Open-Type spec's registered
-        design-variation tag 'wght' available at
-        https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_wght
-        does not specify a required value for the 'Bold' instance of a variable font.
-
-        But Dave Crossland suggested that we should enforce
-        a required value of 700 in this case (NOTE: a distinction
-        is made between "no bold instance present" vs "bold instance is present
-        but its wght coordinate is not == 700").
-    """,
-    conditions=["is_variable_font", "has_wght_axis"],
-    proposal="https://github.com/fonttools/fontbakery/issues/1707",
-)
-def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
-    """
-    The variable font 'wght' (Weight) axis coordinate must be 700 on the 'Bold'
-    instance.
-    """
-    from .shared_conditions import wght_axis
-
-    wght = wght_axis(ttFont)
-    if bold_wght_coord is None:
-        if wght and wght.maxValue < 700:
-            yield SKIP, Message("no-bold-weight", "Weight axis doesn't go up to bold")
-            return
-        yield FAIL, Message("no-bold-instance", '"Bold" instance not present.')
-    elif bold_wght_coord == 700:
-        yield PASS, "Bold:wght is 700."
-    else:
-        yield FAIL, Message(
-            "wght-not-700",
-            f'The "wght" axis coordinate of'
-            f' the "Bold" instance must be 700.'
-            f" Got {bold_wght_coord} instead.",
-        )
-
-
-@check(
     id="com.google.fonts/check/varfont/wght_valid_range",
     rationale="""
         According to the Open-Type spec's

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -222,6 +222,7 @@ FONT_FILE_CHECKS = [
     "com.google.fonts/check/colorfont_tables",
     "com.google.fonts/check/color_cpal_brightness",
     "com.google.fonts/check/empty_glyph_on_gid1_for_colrv0",
+    "com.google.fonts/check/varfont/bold_wght_coord",
 ]
 
 GOOGLEFONTS_PROFILE_CHECKS = (
@@ -7446,6 +7447,46 @@ def com_google_fonts_check_metadata_empty_designer(family_metadata):
     # (and then maybe rename the check-id)
     else:
         yield PASS, "Font designer field is not empty."
+
+
+@check(
+    id="com.google.fonts/check/varfont/bold_wght_coord",
+    rationale="""
+        The Open-Type spec's registered
+        design-variation tag 'wght' available at
+        https://docs.microsoft.com/en-gb/typography/opentype/spec/dvaraxistag_wght
+        does not specify a required value for the 'Bold' instance of a variable font.
+
+        But Dave Crossland suggested that we should enforce
+        a required value of 700 in this case (NOTE: a distinction
+        is made between "no bold instance present" vs "bold instance is present
+        but its wght coordinate is not == 700").
+    """,
+    conditions=["is_variable_font", "has_wght_axis"],
+    proposal="https://github.com/fonttools/fontbakery/issues/1707",
+)
+def com_google_fonts_check_varfont_bold_wght_coord(ttFont, bold_wght_coord):
+    """
+    The variable font 'wght' (Weight) axis coordinate must be 700 on the 'Bold'
+    instance.
+    """
+    from .shared_conditions import wght_axis
+
+    wght = wght_axis(ttFont)
+    if bold_wght_coord is None:
+        if wght and wght.maxValue < 700:
+            yield SKIP, Message("no-bold-weight", "Weight axis doesn't go up to bold")
+            return
+        yield FAIL, Message("no-bold-instance", '"Bold" instance not present.')
+    elif bold_wght_coord == 700:
+        yield PASS, "Bold:wght is 700."
+    else:
+        yield FAIL, Message(
+            "wght-not-700",
+            f'The "wght" axis coordinate of'
+            f' the "Bold" instance must be 700.'
+            f" Got {bold_wght_coord} instead.",
+        )
 
 
 ###############################################################################

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -46,7 +46,6 @@ OPENTYPE_PROFILE_CHECKS = [
     "com.google.fonts/check/varfont/regular_slnt_coord",
     "com.google.fonts/check/varfont/regular_ital_coord",
     "com.google.fonts/check/varfont/regular_opsz_coord",
-    "com.google.fonts/check/varfont/bold_wght_coord",
     "com.google.fonts/check/varfont/slnt_range",
     "com.typenetwork/check/varfont/ital_range",
     "com.google.fonts/check/varfont/wght_valid_range",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -102,7 +102,6 @@ SET_EXPLICIT_CHECKS = {
     "com.google.fonts/check/varfont/regular_slnt_coord",  # OVERRIDEN: Lowered to WARN
     "com.google.fonts/check/varfont/regular_ital_coord",  # OVERRIDEN: Lowered to WARN
     "com.google.fonts/check/varfont/regular_opsz_coord",  # OVERRIDEN: Lowered to WARN
-    "com.google.fonts/check/varfont/bold_wght_coord",  # OVERRIDEN: Lowered to WARN
     "com.google.fonts/check/varfont/wght_valid_range",
     "com.google.fonts/check/varfont/wdth_valid_range",
     "com.google.fonts/check/varfont/slnt_range",
@@ -157,6 +156,7 @@ SET_EXPLICIT_CHECKS = {
     # "com.google.fonts/check/os2/use_typo_metrics", # Removed in favor of
     #                                                # new vmetrics check
     # "com.google.fonts/check/metadata/empty_designer", # Review
+    "com.google.fonts/check/varfont/bold_wght_coord",  # OVERRIDEN: Lowered to WARN
     #
     # =======================================
     # From gpos.py
@@ -1775,7 +1775,7 @@ profile.check_log_override(
 )
 
 profile.check_log_override(
-    # From fvar.py
+    # From googlefonts.py
     "com.google.fonts/check/varfont/bold_wght_coord",
     overrides=(
         ("no-bold-instance", WARN, KEEP_ORIGINAL_MESSAGE),

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -257,31 +257,6 @@ def test_check_varfont_regular_opsz_coord():
     assert msg == ('"Regular" instance not present.')
 
 
-def test_check_varfont_bold_wght_coord():
-    """The variable font 'wght' (Weight) axis coordinate
-    must be 700 on the 'Bold' instance."""
-    check = CheckTester(
-        opentype_profile, "com.google.fonts/check/varfont/bold_wght_coord"
-    )
-
-    # Our reference varfont CabinVFBeta.ttf
-    # has a good Bold:wght coordinate
-    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
-    assert_PASS(check(ttFont), "with a good Bold:wght coordinate...")
-
-    # We then change the value to ensure the problem is properly detected by the check:
-    ttFont["fvar"].instances[3].coordinates["wght"] = 600
-    assert_results_contain(
-        check(ttFont), FAIL, "wght-not-700", "with a bad Bold:wght coordinage (600)..."
-    )
-
-    # Check we skip when we don't have a 700 weight.
-    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
-    del ttFont["fvar"].instances[3]
-    ttFont["fvar"].axes[0].maxValue = 600
-    assert_results_contain(check(ttFont), SKIP, "no-bold-weight")
-
-
 def test_check_varfont_wght_valid_range():
     """The variable font 'wght' (Weight) axis coordinate
     must be within spec range of 1 to 1000 on all instances."""

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -5330,3 +5330,28 @@ def test_check_shape_languages():
 
     test_font = TTFont(TEST_FILE("annie/AnnieUseYourTelescope-Regular.ttf"))
     assert_results_contain(check(test_font), FAIL, "failed-language-shaping")
+
+
+def test_check_varfont_bold_wght_coord():
+    """The variable font 'wght' (Weight) axis coordinate
+    must be 700 on the 'Bold' instance."""
+    check = CheckTester(
+        googlefonts_profile, "com.google.fonts/check/varfont/bold_wght_coord"
+    )
+
+    # Our reference varfont CabinVFBeta.ttf
+    # has a good Bold:wght coordinate
+    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+    assert_PASS(check(ttFont), "with a good Bold:wght coordinate...")
+
+    # We then change the value to ensure the problem is properly detected by the check:
+    ttFont["fvar"].instances[3].coordinates["wght"] = 600
+    assert_results_contain(
+        check(ttFont), FAIL, "wght-not-700", "with a bad Bold:wght coordinage (600)..."
+    )
+
+    # Check we skip when we don't have a 700 weight.
+    ttFont = TTFont("data/test/cabinvfbeta/CabinVFBeta.ttf")
+    del ttFont["fvar"].instances[3]
+    ttFont["fvar"].axes[0].maxValue = 600
+    assert_results_contain(check(ttFont), SKIP, "no-bold-weight")


### PR DESCRIPTION
**com.google.fonts/check/varfont/bold_wght_coord**

(issue #4436)