### PR TITLE
Refactor terminal reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - The babelfont dependency has been dropped. (PR #4416)
   - Fix a crash when no matching checks are found during a multi-processing run. Also, do not freeze indefinitely. Instead, terminate the program emitting a process error code -1 and giving the user some guidance. (issue #4420)
+  - Reporters have been refactored; there may be some changes to the terminal display, particularly when --succinct is passed. (PR #4447)
 
 ### Migration of checks
 #### Moved to the Google Fonts profile

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -189,6 +189,7 @@ And a  [message-skip]SKIP[/] happens when the check does not apply to the given 
 
 """
 
+
 class NameID(enum.IntEnum):
     """nameID definitions for the name table"""
 

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -15,6 +15,8 @@
 #
 import enum
 
+from rich.theme import Theme
+
 # =====================================
 # GLOBAL CONSTANTS DEFINITIONS
 
@@ -68,101 +70,124 @@ SHOW_GF_DOCS_MSG = (
     "https://github.com/googlefonts/gf-docs/tree/main/Spec"
 )
 
+NO_COLORS_THEME = Theme(
+    {
+        "header": "",
+        "url": "",
+        "check-id": "",
+        "description": "",
+        "experimental": "",
+        "rationale-title": "",
+        "rationale-text": "",
+        "message-info": "",
+        "message-warn": "",
+        "message-error": "",
+        "message-skip": "",
+        "message-pass": "",
+        "message-fail": "",
+        "message-fatal": "",
+        "message-cupcake": "",
+        "message-spinner": "",
+        "list-checks: section": "",
+        "list-checks: check-id": "",
+        "list-checks: description": "",
+    }
+)
 
-# ANSI color codes for the helper logging class:
-def color(bg, fg, bold=False):
-    return (f"\033[{int(bold)};{bg};{fg + 10}m" "{}\033[0m").format
+DARK_THEME = Theme(
+    {
+        "header": "bold white on black",
+        "url": "bold cyan on black",
+        "check-id": "bold cyan on black",
+        "description": "magenta on black",
+        "experimental": "bright_yellow on black",
+        "rationale-title": "bold bright_cyan on bright_black",
+        "rationale-text": "white on black",
+        "message-info": "cyan on black",
+        "message-warn": "yellow on black",
+        "message-error": "bright_white on red",
+        "message-skip": "blue on black",
+        "message-pass": "green on black",
+        "message-fail": "red on black",
+        "message-fatal": "black on bright_yellow",
+        "cupcake": "magenta on black",
+        "spinner": "green on black",
+        "list-checks: section": "white on black",
+        "list-checks: check-id": "cyan on black",
+        "list-checks: description": "blue on black",
+    }
+)
 
+LIGHT_THEME = Theme(
+    {
+        # Foreground, Background
+        "header": "bold black on bright_white",
+        "url": "bold cyan on bright_white",
+        "check-id": "bold magenta on bright_white",
+        "description": "cyan on bright_white",
+        "experimental": "black on bright_yellow",
+        "rationale-title": "bold magenta on bright_white",
+        "rationale-text": "black on bright_white",
+        "message-info": "cyan on bright_white",
+        "message-warn": "bold black on bright_yellow",
+        "message-error": "bold bright_white on bright_red",
+        "message-skip": "blue on bright_white",
+        "message-pass": "green on bright_white",
+        "message-fail": "bold bright_red on bright_white",
+        "message-fatal": "bold black on bright_yellow",
+        "cupcake": "magenta on bright_white",
+        "spinner": "green on bright_white",
+        "list-checks: section": "bold white on bright_white",
+        "list-checks: check-id": "bold cyan on bright_white",
+        "list-checks: description": "blue on bright_white",
+    }
+)
 
-def no_color(s):
-    return s
+CUPCAKE = r"""
+                           ,@.
+                         ,@.@@,.
+                   ,@@,.@@@.  @.@@@,.
+                 ,@@. @@@.     @@. @@,.
+         ,@@@.@,.@.              @.  @@@@,.@.@@,.
+    ,@@.@.     @@.@@.            @,.    .@’ @’  @@,
+  ,@@. @.          .@@.@@@.  @@’                  @,
+ ,@.  @@.                                          @,
+ @.     @,@@,.     ,                             .@@,
+ @,.       .@,@@,.         .@@,.  ,       .@@,  @, @,
+ @.                             .@. @ @@,.    ,      @
+  @,.@@.     @,.      @@,.      @.           @,.    @’
+   @@||@,.  @’@,.       @@,.  @@ @,.        @’@@,  @’
+      \\@@@@’  @,.      @’@@@@’   @@,.   @@@’ //@@@’
+       |||||||| @@,.  @@’ |||||||  |@@@|@||  ||
+        \\\\\\\  ||@@@||  |||||||  |||||||  //
+         |||||||  ||||||  ||||||   ||||||  ||
+          \\\\\\  ||||||  ||||||  ||||||  //
+           ||||||  |||||  |||||   |||||  ||
+            \\\\\  |||||  |||||  |||||  //
+             |||||  ||||  |||||  ||||  ||
+              \\\\  ||||  ||||  ||||  //
+               ||||||||||||||||||||||||
 
+         No check is failing. Get a cupcake!
+       <<Art by Tony de Marco, July 26, 2018>>
+"""
 
-BLACK = 30
-RED = 31
-GREEN = 32
-YELLOW = 33
-BLUE = 34
-MAGENTA = 35
-CYAN = 36
-WHITE = 37
-BRIGHT_BLACK = 90
-BRIGHT_RED = 91
-BRIGHT_GREEN = 92
-BRIGHT_YELLOW = 93
-BRIGHT_BLUE = 94
-BRIGHT_MAGENTA = 95
-BRIGHT_CYAN = 96
-BRIGHT_WHITE = 97
+MEANING_MESSAGE = """
+    [header]Meaning of check results:[/]
 
-NO_COLORS_THEME = {
-    "header": no_color,
-    "url": no_color,
-    "check-id": no_color,
-    "description": no_color,
-    "experimental": no_color,
-    "rationale-title": no_color,
-    "rationale-text": no_color,
-    "INFO": no_color,
-    "WARN": no_color,
-    "ERROR": no_color,
-    "SKIP": no_color,
-    "PASS": no_color,
-    "FAIL": no_color,
-    "FATAL": no_color,
-    "cupcake": no_color,
-    "spinner": no_color,
-    "list-checks: section": no_color,
-    "list-checks: check-id": no_color,
-    "list-checks: description": no_color,
-}
+    An [message-error]ERROR[/] is something wrong with FontBakery itself, possibly a bug.
+    A  [message-fatal]FATAL[/] is an extremely severe issue that must be addressed immediately.
+    A  [message-fail]FAIL[/] is a problem with the font that must be fixed.
+    A  [message-warn]WARN[/] is something that you should consider addressing.
+    An [message-info]INFO[/] result simply prints something useful. Typically stats.
+    A  [message-pass]PASS[/] means the font looks good for the given checking routine.
+And a  [message-skip]SKIP[/] happens when the check does not apply to the given font.
 
-DARK_THEME = {
-    # Foreground, Background
-    "header": color(WHITE, BLACK, bold=True),
-    "url": color(CYAN, BLACK, bold=True),
-    "check-id": color(CYAN, BLACK, bold=True),
-    "description": color(MAGENTA, BLACK),
-    "experimental": color(BRIGHT_YELLOW, BLACK),
-    "rationale-title": color(BRIGHT_CYAN, BRIGHT_BLACK, bold=True),
-    "rationale-text": color(WHITE, BLACK),
-    "INFO": color(CYAN, BLACK),
-    "WARN": color(YELLOW, BLACK),
-    "ERROR": color(BRIGHT_WHITE, RED),
-    "SKIP": color(BLUE, BLACK),
-    "PASS": color(GREEN, BLACK),
-    "FAIL": color(RED, BLACK),
-    "FATAL": color(BLACK, BRIGHT_YELLOW),
-    "cupcake": color(MAGENTA, BLACK),
-    "spinner": color(GREEN, BLACK),
-    "list-checks: section": color(WHITE, BLACK),
-    "list-checks: check-id": color(CYAN, BLACK),
-    "list-checks: description": color(BLUE, BLACK),
-}
+    If you get [message-error]ERROR[/]s, please help us improve the tool by reporting them at
+    https://github.com/fonttools/fontbakery/issues (but other kinds of bug
+    reports and/or feature requests are also always welcome, of course!)
 
-LIGHT_THEME = {
-    # Foreground, Background
-    "header": color(BLACK, BRIGHT_WHITE, bold=True),
-    "url": color(CYAN, BRIGHT_WHITE, bold=True),
-    "check-id": color(MAGENTA, BRIGHT_WHITE, bold=True),
-    "description": color(CYAN, BRIGHT_WHITE),
-    "experimental": color(BLACK, BRIGHT_YELLOW),
-    "rationale-title": color(MAGENTA, BRIGHT_WHITE, bold=True),
-    "rationale-text": color(BLACK, BRIGHT_WHITE),
-    "INFO": color(CYAN, BRIGHT_WHITE),
-    "WARN": color(BLACK, BRIGHT_YELLOW, bold=True),
-    "ERROR": color(BRIGHT_WHITE, BRIGHT_RED, bold=True),
-    "SKIP": color(BLUE, BRIGHT_WHITE),
-    "PASS": color(GREEN, BRIGHT_WHITE),
-    "FAIL": color(BRIGHT_RED, BRIGHT_WHITE, bold=True),
-    "FATAL": color(BLACK, BRIGHT_YELLOW, bold=True),
-    "cupcake": color(MAGENTA, BRIGHT_WHITE),
-    "spinner": color(GREEN, BRIGHT_WHITE),
-    "list-checks: section": color(WHITE, BRIGHT_WHITE, bold=True),
-    "list-checks: check-id": color(CYAN, BRIGHT_WHITE, bold=True),
-    "list-checks: description": color(BLUE, BRIGHT_WHITE),
-}
-
+"""
 
 class NameID(enum.IntEnum):
     """nameID definitions for the name table"""

--- a/Lib/fontbakery/reporters/__init__.py
+++ b/Lib/fontbakery/reporters/__init__.py
@@ -25,7 +25,6 @@ class FontbakeryReporter:
     collect_results_by: Optional[str] = None
     succinct: bool = False
 
-
     def __post_init__(self):
         self._started = None
         self._ended = None

--- a/Lib/fontbakery/reporters/serialize.py
+++ b/Lib/fontbakery/reporters/serialize.py
@@ -43,7 +43,7 @@ class SerializeReporter(FontbakeryReporter):
 
     def omit_loglevel(self, msg) -> bool:
         """Determine if message is below log level."""
-        return self.loglevels and (self.loglevels[0] > Status(msg))
+        return bool(self.loglevels) and (self.loglevels[0] > Status(msg))
 
     def _register(self, event):
         super()._register(event)

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -305,11 +305,12 @@ class TerminalReporter(FontbakeryReporter):
                     unindent_and_unwrap_rationale(check.rationale), "rationale-text"
                 )
                 self.add_to_event_buffer(
-                    event, "\n   [rationale_title]Rationale:" + " " * 64 + "[/]"
+                    event, "\n   [rationale_title]Rationale:" + " " * 64 + "[/]\n"
                 )
                 lines = content.wrap(self._console, self._console.width - 6)
                 for line in lines._lines:
                     line.pad_left(4)
+                    line.set_length(self._console.width)
                 self.add_to_event_buffer(event, lines)
 
             if check.suggested_profile:

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -15,7 +15,6 @@ Conditions) and MAYBE in *customized* reporters e.g. subclasses.
 from dataclasses import dataclass
 import os
 import re
-import subprocess
 import sys
 from typing import Optional
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,14 +8,10 @@ from fontbakery.constants import (
     NO_COLORS_THEME,
     DARK_THEME,
     LIGHT_THEME,
-    color,
-    WHITE,
-    BLACK,
 )
 from fontbakery.utils import (
     apple_terminal_bg_is_white,
     bullet_list,
-    colorless_len,
     exit_with_install_instructions,
     get_apple_terminal_bg_color,
     get_theme,
@@ -23,7 +19,6 @@ from fontbakery.utils import (
     is_negated,
     pretty_print_list,
     split_camel_case,
-    text_flow,
     unindent_and_unwrap_rationale,
 )
 
@@ -66,111 +61,6 @@ def test_remove_white_space():
 )
 def test_is_negated(input_str, expected_tup):
     assert is_negated(input_str) == expected_tup
-
-
-@pytest.mark.parametrize(
-    "input_str, expected_len",
-    [
-        ("", 0),
-        ("abc", 3),
-        (" abc ", 5),
-        (color(WHITE, BLACK, bold=True)("abc"), 3),
-        (color(WHITE, BLACK)("abc"), 3),
-    ],
-)
-def test_colorless_len(input_str, expected_len):
-    assert colorless_len(input_str) == expected_len
-
-
-# NOTE: The 'color()' method is in 'constants.py'
-def test_color():
-    assert color(WHITE, BLACK, bold=True)("abc") == "\x1b[1;37;40mabc\x1b[0m"
-    assert color(WHITE, BLACK)("abc") == "\x1b[0;37;40mabc\x1b[0m"
-
-
-def test_text_flow():
-    assert text_flow("") == ""
-
-    assert text_flow("Testing") == "Testing"
-
-    assert text_flow("One Two Three") == "One Two Three"
-
-    assert text_flow("One Two Three", width=5) == "One\nTwo\nThree"
-
-    assert (
-        text_flow("One Two\n\nThree", width=5, space_padding=True)
-        == "One  \nTwo  \n     \nThree"
-    )
-
-    assert (
-        text_flow("One Two Three", width=6, space_padding=True)
-        == "One   \nTwo   \nThree "
-    )
-
-    assert text_flow("One Two\n\nThree", width=10) == "One Two\nThree"
-
-    assert text_flow("One Two Three", width=7, space_padding=True) == "One Two\nThree  "
-
-    assert (
-        text_flow("One Two Three", width=9, left_margin=2, space_padding=True)
-        == "  One Two\n  Three  "
-    )
-
-    assert (
-        text_flow("One Two Three", width=7, left_margin=1, space_padding=True)
-        == " One   \n Two   \n Three "
-    )
-
-    assert (
-        text_flow(
-            "One Two Three", width=9, left_margin=1, right_margin=1, space_padding=True
-        )
-        == " One Two \n Three   "
-    )
-
-    assert (
-        text_flow(
-            "One Two Three", width=8, left_margin=1, right_margin=1, space_padding=True
-        )
-        == " One    \n Two    \n Three  "
-    )
-
-    assert (
-        text_flow(
-            "One Two Three Four",
-            width=7,
-            left_margin=1,
-            right_margin=1,
-            space_padding=True,
-        )
-        == " One   \n Two   \n Three \n Four  "
-    )
-
-    assert (
-        text_flow(
-            "One Two Three Four",
-            width=6,
-            left_margin=1,
-            right_margin=1,
-            space_padding=True,
-        )
-        == " One  \n Two  \n Thre \n e    \n Four "
-    )
-
-    assert (
-        text_flow("https://learn.microsoft.com/typography/opentype/spec/name", width=30)
-        == "https://learn.microsoft.com\n/typography/opentype/spec/name"
-    )
-
-
-# FIXME!
-#    assert text_flow("One Two Three",
-#                     width=12,
-#                     left_margin=6,
-#                     first_line_indent=-5,
-#                     space_padding=True) == (     " One   \n"
-#                                             "      Two   \n"
-#                                             "      Three ")
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
## Description

This is a substantial change to the reporters framework. It:

* Ensures all reporters take the same arguments.
* Moves some common code into the base class.
* Merges the "ProgressReporter" and "TerminalReporter" subclasses into the same class.
* Makes heavy use of the `rich` library for text formatting, simplifying the layout.
* Improves the progress bar by making it a separate `rich` renderable, kept as a "live display" at the bottom of the terminal.
* Splits the rendering of events into one method per event type.
* Makes the `--succinct` flag truly succinct, just showing checks, arguments and their status codes on a single line.
* Removes some unused methods.

Probably does some other things too. :-)

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

