### PR TITLE
terminal: render FailedCheckError correctly

### DIFF
--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -18,6 +18,7 @@ from fontbakery.constants import LIGHT_THEME, CUPCAKE, MEANING_MESSAGE
 from fontbakery.message import Message
 from fontbakery.result import CheckResult
 from fontbakery.reporters import FontbakeryReporter
+from fontbakery.errors import FailedCheckError
 
 from fontbakery.status import (
     DEBUG,
@@ -338,8 +339,13 @@ class TerminalReporter(FontbakeryReporter):
             message += traceback
 
         self._console.print(f"    [message-{status.name.lower()}]{status.name}[/] ")
+        text = (
+            str(msg.message)
+            if isinstance(msg.message, FailedCheckError)
+            else msg.message
+        )
         self._console.print(
-            IndentedParagraph(Markdown(msg.message), right=2, left=10, first=0),
+            IndentedParagraph(Markdown(text), right=2, left=10, first=0),
         )
 
         if status not in statuses:


### PR DESCRIPTION
Currently, the terminal reporter will raise the following traceback if a check raises a FailedCheckError:

```PYTHON
Traceback (most recent call last):
  File "/Users/marcfoley/Type/tools/venv/bin/fontbakery", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/cli.py", line 61, in main
    run_profile_check(subcommand_module[6:])
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/cli.py", line 34, in run_profile_check
    sys.exit(check_profile_main(module.profile))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/commands/check_profile.py", line 471, in main
    runner.run(reporters)
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/checkrunner.py", line 499, in run
    run_a_check(identity)
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/checkrunner.py", line 488, in run_a_check
    reporter.receive_result(result)
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/reporters/terminal.py", line 293, in receive_result
    self._render_subresult(result)
  File "/Users/marcfoley/Type/fontbakery/Lib/fontbakery/reporters/terminal.py", line 342, in _render_subresult
    IndentedParagraph(Markdown(msg.message), right=2, left=10, first=0),
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/marcfoley/Type/tools/venv/lib/python3.11/site-packages/rich/markdown.py", line 567, in __init__
    self.parsed = parser.parse(markup)
                  ^^^^^^^^^^^^^^^^^^^^
  File "/Users/marcfoley/Type/tools/venv/lib/python3.11/site-packages/markdown_it/main.py", line 274, in parse
    raise TypeError(f"Input data should be a string, not {type(src)}")
TypeError: Input data should be a string, not <class 'fontbakery.errors.FailedCheckError'>
░ [E.] 50%(venv) Marcs-Air-2:var marcfoley$ fontbakery check-googlefonts /Users/marcfoley/Type/upstream_repos/inter/builr/gf/Inter-Italic\[opsz\,wght\].ttf /Users/marcfoley/Type/upstream_repos/inter/build/fonts/var/gf/Inter\[opsz\,wght\].ttf -l FAIL -c com.google.fonts/check/glyph_coverage
```

This is happening because we're asking Rich to render an error when it expects a string.

@simoncozens my fix here may not be the best place. I did think about implementing the fix further up the stack but I'm worried I may break other stuff. I find it absolutely insane how little checks we have for the runner, reporter etc. It's incredibly complex code that may actually end up getting simplified if we write some tests