### PR TITLE
Use `ttFont.getBestCmap()` to avoid potential ERROR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Universal Profile
   - **[com.google.fonts/check/arabic_spacing_symbols]:** Also check U+FBC2 ARABIC SYMBOL WASLA ABOVE (issue #4417)
+  - **[com.google.fonts/check/contour_count]:** Use `ttFont.getBestCmap()` to avoid potential ERROR. (issue #3601)
 
 #### On the OpenType Profile
   - **[com.google.fonts/check/varfont/bold_wght_coord]:** Only check for a bold instance on fonts where the weight range extends to 700. (issue #4373)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -5,7 +5,6 @@ from typing import List
 from packaging.version import VERSION_PATTERN
 
 from fontbakery.callable import check, disable
-from fontbakery.constants import PlatformID, WindowsEncodingID
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.glyphdata import desired_glyph_data
 from fontbakery.message import Message
@@ -1727,11 +1726,7 @@ def com_google_fonts_check_contour_count(ttFont, config):
                 )
 
         if len(bad_glyphs) > 0:
-            cmap = (
-                ttFont["cmap"]
-                .getcmap(PlatformID.WINDOWS, WindowsEncodingID.UNICODE_BMP)
-                .cmap
-            )
+            cmap = ttFont.getBestCmap()
 
             def _glyph_name(cmap, name):
                 if name in cmap:


### PR DESCRIPTION
**com.google.fonts/check/contour_count**

On the Universal profile.

(issue #3601)