### PR TITLE
Fix display of messages and codes on all reporters

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -132,7 +132,7 @@ class CheckRunner:
             return Subresult(FAIL, Message("api-violation", msg))
 
         if not isinstance(message, Message):
-            message = Message("", message)
+            message = Message(None, message)
 
         return Subresult(status, message)
 

--- a/Lib/fontbakery/message.py
+++ b/Lib/fontbakery/message.py
@@ -26,7 +26,10 @@ class Message:
         self.message = message
 
     def __repr__(self):
-        return f"{self.message} [code: {self.code}]"
+        if self.code:
+            return f"{self.message} [code: {self.code}]"
+        else:
+            return f"{self.message}"
 
     def getData(self):
         """return a dictionary with data suitable for serialization,

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -32,8 +32,12 @@ class GHMarkdownReporter(SerializeReporter):
 
     def log_md(self, log):
         if not self.omit_loglevel(log["status"]):
+            msg = log["message"]
+            message = msg["message"]
+            if msg["code"]:
+                message += f" [code: {msg['code']}]"
             return "* {} **{}** {}\n".format(
-                self.emoticon(log["status"]), log["status"], log["message"]
+                self.emoticon(log["status"]), log["status"], message
             )
         else:
             return ""

--- a/Lib/fontbakery/reporters/templates/html/check.html
+++ b/Lib/fontbakery/reporters/templates/html/check.html
@@ -28,7 +28,10 @@
                             {{log["status"] | emoticon}} {{log["status"]}}
                             </span>
                             <span class='details_text'>
-                            {{(log["message"]["message"] ~ " [code: " ~ log["message"]["code"] ~ "]") | markdown}}
+                            {{log["message"]["message"] | markdown}}
+                            {% if log["message"]["code"] %}
+                            {{" [code: " ~ log["message"]["code"] ~ "]"}}
+                            {% endif %}
                         </li>
                 {% endfor %}
                 </ul>

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -335,7 +335,7 @@ class TerminalReporter(FontbakeryReporter):
         if not isinstance(msg, Message):
             raise (TypeError(f"Expected Message, got {type(msg)}: {msg}"))
 
-        message = f"{msg.message} [code: {msg.code}]"
+        message = str(msg)
 
         if hasattr(msg, "traceback"):
             message = re.sub(r"(<[^<>]*>)", r"**`\1`**", message, flags=re.MULTILINE)


### PR DESCRIPTION
Only display code if not None (in general, a PASS would not have a code-word)

(issue #4467)