### PR TITLE
Also consider the case of glyphs which are components only of unreachable glyphs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fixed HTML reporter by adding the templates directory to the fontbakery package. (issue #4479)
   - Minor wording improvement on the GHMarkdown reporter (issue #4492)
 
+### Changes to existing checks
+#### On the Universal Profile
+  - **[com.google.fonts/check/unreachable_glyphs]:** Also consider the case of glyphs which are components only of unreachable glyphs. (issue #4378)
+
+
 ## 0.11.0 (2024-Feb-02)
 ### Noteworthy code-changes
   - The babelfont dependency has been dropped. (PR #4416)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -1599,7 +1599,7 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
     if "glyf" in ttFont:
         for glyph_name in ttFont["glyf"].keys():
             base_glyph = ttFont["glyf"][glyph_name]
-            if base_glyph.isComposite():
+            if base_glyph.isComposite() and glyph_name not in all_glyphs:
                 all_glyphs -= set(base_glyph.getComponentNames(ttFont["glyf"]))
 
     if all_glyphs:


### PR DESCRIPTION
**com.google.fonts/check/unreachable_glyphs**
On the Universal Profile

(issue #4378)