### PR TITLE
Cache condition results

### DIFF
--- a/Lib/fontbakery/callable.py
+++ b/Lib/fontbakery/callable.py
@@ -13,7 +13,7 @@ Conditions) and MAYBE in *customized* reporters e.g. subclasses.
 """
 import inspect
 
-from functools import wraps, update_wrapper
+from functools import update_wrapper, cached_property
 from typing import Callable
 
 
@@ -245,8 +245,9 @@ def condition(cls):
 
     def decorator(*args, **kwds):
         func = args[0]
-        # We should also cache this
-        setattr(cls, func.__name__, property(func))
+        prop = cached_property(func)
+        prop.__set_name__(cls, func.__name__)
+        setattr(cls, func.__name__, prop)
 
     return decorator
 

--- a/Lib/fontbakery/callable.py
+++ b/Lib/fontbakery/callable.py
@@ -17,22 +17,6 @@ from functools import update_wrapper, cached_property
 from typing import Callable
 
 
-def cached_getter(func):
-    """Decorate a property by executing it at instatiation time and cache the
-    result on the instance object."""
-
-    @wraps(func)
-    def wrapper(self):
-        attribute = f"_{func.__name__}"
-        value = getattr(self, attribute, None)
-        if value is None:
-            value = func(self)
-            setattr(self, attribute, value)
-        return value
-
-    return wrapper
-
-
 class FontbakeryCallable:
     __wrapped__: Callable
 
@@ -56,13 +40,11 @@ class FontbakeryCallable:
             getattr(self, "id", getattr(self, "name", super().__repr__())),
         )  # pylint: disable=consider-using-f-string
 
-    @property
-    @cached_getter
+    @cached_property
     def args(self):
         return self.mandatoryArgs + self.optionalArgs
 
-    @property
-    @cached_getter
+    @cached_property
     def mandatoryArgs(self):
         args = []
         # make follow_wrapped=True explicit, even though it is the default!
@@ -84,8 +66,7 @@ class FontbakeryCallable:
             args.append(name)
         return tuple(args)
 
-    @property
-    @cached_getter
+    @cached_property
     def optionalArgs(self):
         args = []
         # make follow_wrapped=True explicit, even though it is the default!


### PR DESCRIPTION
## Description

When I refactored conditions, I refactored them into *properties* - which are executed each time they are called. Some of the more common ones (e.g. `ttFont`) were explicitly "pre-prepared" as `@cached_property` methods on the testable object. But anything defined as a `@condition(Font)` was a plain ol' property. This makes them into `cached_property`s.

`check-googlefonts --skip-network data/test/cabin/Cabin-*` goes from 1m19s to 44s on my machine.

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

