### PR TITLE
Lock reporting when returning results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.12.0 (2024-Feb-??)
+  - **[multi-threading]:** Lock reporting when returning results. (issue #4494)
   - Added support for checking TTC (OpenType font collection) files. (issue #2595)
   - And also includes the changes from the previous release-candidate v0.12.0a1 (2024-Feb-14)
 

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -274,6 +274,7 @@ class CheckRunner:
             reporter.start(self.order)
 
         reporter_lock = threading.Lock()
+
         def distribute_result(result):
             with reporter_lock:
                 for reporter in reporters:
@@ -285,7 +286,9 @@ class CheckRunner:
             ) as executor:
                 for identity in self.order:
                     future = executor.submit(self._run_check, identity)
-                    future.add_done_callback(lambda future: distribute_result(future.result()))
+                    future.add_done_callback(
+                        lambda future: distribute_result(future.result())
+                    )
         else:
             for identity in self.order:
                 result = self._run_check(identity)


### PR DESCRIPTION
## Description
Relates to issue #4494

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

