### PR TITLE
fix html reporter

### DIFF
--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -88,6 +88,7 @@ class CheckTester:
         else:
             # We create a fake profile containing just this check
             self.profile = Profile(
+                name="TestProfile",
                 iterargs={val.singular: val.plural for val in FILE_TYPES},
                 sections=[
                     Section(

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -20,7 +20,12 @@ from fontbakery.status import (
 from fontbakery.configuration import Configuration
 from fontbakery.profile import Profile
 from fontbakery.errors import ValueValidationError
-from fontbakery.fonts_profile import profile_factory, get_module, setup_context
+from fontbakery.fonts_profile import (
+    profile_factory,
+    get_module,
+    setup_context,
+    ITERARGS,
+)
 from fontbakery.reporters.terminal import TerminalReporter
 from fontbakery.reporters.serialize import SerializeReporter
 from fontbakery.reporters.badge import BadgeReporter
@@ -49,7 +54,7 @@ class AddReporterAction(argparse.Action):
         namespace.reporters.append((self.cls, values))
 
 
-def ArgumentParser(profile, profile_arg=True):
+def ArgumentParser(profile_arg=True):
     argument_parser = argparse.ArgumentParser(
         description="Check TTF files against a profile.",
         formatter_class=argparse.RawTextHelpFormatter,
@@ -242,7 +247,7 @@ def ArgumentParser(profile, profile_arg=True):
         help="Write a HTML report to HTML_FILE.",
     )
 
-    iterargs = sorted(profile.iterargs.keys())
+    iterargs = sorted(ITERARGS.keys())
 
     gather_by_choices = iterargs + ["*check"]
     comma_separated = ", ".join(gather_by_choices)
@@ -342,7 +347,7 @@ class ArgumentParserError(Exception):
 
 def get_profile():
     """Prefetch the profile module, to fill some holes in the help text."""
-    argument_parser = ArgumentParser(Profile(), profile_arg=True)
+    argument_parser = ArgumentParser(profile_arg=True)
 
     # monkey patching will do here
     def error(message):
@@ -369,7 +374,7 @@ def main(profile=None, values=None):
         profile = get_profile()
         add_profile_arg = True
 
-    argument_parser = ArgumentParser(profile, profile_arg=add_profile_arg)
+    argument_parser = ArgumentParser(profile_arg=add_profile_arg)
     try:
         args = argument_parser.parse_args()
     except ValueValidationError as e:

--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -18,7 +18,6 @@ from fontbakery.status import (
     WARN,
 )
 from fontbakery.configuration import Configuration
-from fontbakery.profile import Profile
 from fontbakery.errors import ValueValidationError
 from fontbakery.fonts_profile import (
     profile_factory,
@@ -355,11 +354,7 @@ def get_profile():
 
     argument_parser.error = error
 
-    try:
-        args, _ = argument_parser.parse_known_args()
-    except ArgumentParserError:
-        # silently fails, the main parser will show usage string.
-        return Profile()
+    args, _ = argument_parser.parse_known_args()
     imported = get_module(args.profile)
     profile = profile_factory(imported)
     if not profile:

--- a/Lib/fontbakery/fonts_profile.py
+++ b/Lib/fontbakery/fonts_profile.py
@@ -18,6 +18,9 @@ from fontbakery.errors import ValueValidationError
 from fontbakery.profile import Profile, Section
 
 
+ITERARGS = {val.singular: val.plural for val in FILE_TYPES}
+
+
 def setup_context(files):
     context = CheckRunContext([])
 
@@ -152,7 +155,7 @@ def profile_factory(module):
         name=profile_data.get(
             "name", module.__name__.replace("fontbakery.profiles.", "")
         ),
-        iterargs={val.singular: val.plural for val in FILE_TYPES},
+        iterargs=ITERARGS,
         sections=list(sections.values()),
         overrides=profile_data.get("overrides", {}),
     )

--- a/Lib/fontbakery/fonts_profile.py
+++ b/Lib/fontbakery/fonts_profile.py
@@ -149,7 +149,9 @@ def profile_factory(module):
         )
 
     profile = Profile(
-        name=profile_data.get("name", module.__name__.replace("fontbakery.profiles.", "")),
+        name=profile_data.get(
+            "name", module.__name__.replace("fontbakery.profiles.", "")
+        ),
         iterargs={val.singular: val.plural for val in FILE_TYPES},
         sections=list(sections.values()),
         overrides=profile_data.get("overrides", {}),

--- a/Lib/fontbakery/fonts_profile.py
+++ b/Lib/fontbakery/fonts_profile.py
@@ -149,6 +149,7 @@ def profile_factory(module):
         )
 
     profile = Profile(
+        name=profile_data.get("name", module.__name__.replace("fontbakery.profiles.", "")),
         iterargs={val.singular: val.plural for val in FILE_TYPES},
         sections=list(sections.values()),
         overrides=profile_data.get("overrides", {}),

--- a/Lib/fontbakery/profile.py
+++ b/Lib/fontbakery/profile.py
@@ -17,6 +17,7 @@ class Section:
 
 @dataclass
 class Profile:
+    name: str
     configuration_defaults: dict = field(default_factory=dict)
     sections: Iterable[Section] = field(default_factory=list)
     iterargs: dict = field(default_factory=dict)

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -57,7 +57,7 @@ class HTMLReporter(SerializeReporter):
         total = 0
         loaders = [PackageLoader("fontbakery.reporters", "templates/html")]
         try:
-            profile = self.runner.profile.profile_tag
+            profile = self.runner.profile.name
             loaders.insert(
                 0,
                 PackageLoader("fontbakery.reporters", "templates/" + profile + "/html"),

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -498,24 +498,6 @@ def filenames_ending_in(suffix, root):
     return filenames
 
 
-def add_check_overrides(checkids, profile_tag, overrides):
-    """
-    Overridden checkids have a suffix identifying the specific
-    profile that customize their behaviour.
-
-    This helper function adds them to the list of checks and
-    ensures the original check is not redundantly listed.
-    """
-
-    # First we add the overridden check ids:
-    checkids += [f"{checkid}:{profile_tag}" for checkid in overrides]
-
-    # But then we also remove the original check ids that
-    # may have also been included from the original profile:
-    checkids[:] = [checkid for checkid in checkids if checkid not in overrides]
-    return checkids
-
-
 def all_kerning(ttFont):
     if "GPOS" not in ttFont:
         return []


### PR DESCRIPTION
## Description

I busted the HTML reporter when I took `profile_tag` away. This adds back a `.name` property.

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

