### PR TITLE
Make hinting_stats have its own ttFont instance

### DIFF
--- a/Lib/fontbakery/checks/googlefonts/hinting.py
+++ b/Lib/fontbakery/checks/googlefonts/hinting.py
@@ -1,5 +1,7 @@
 import os
 
+from fontTools.ttLib import TTFont
+
 from fontbakery.prelude import check, Message, INFO, PASS, FAIL, WARN, SKIP
 from fontbakery.constants import LATEST_TTFAUTOHINT_VERSION, NameID
 from fontbakery.utils import filesize_formatting
@@ -16,7 +18,7 @@ def hinting_stats(font: Font):
     from fontTools.subset import main as pyftsubset
 
     hinted_size = os.stat(font.file).st_size
-    ttFont = font.ttFont
+    ttFont = TTFont(font.file)  # Use our own copy since we will dehint it
 
     if font.is_ttf:
         dehinted_buffer = BytesIO()


### PR DESCRIPTION
## Description

Fixes issue #4525. The problem is that conditions are meant to be invariant. In theory, the result of conditions were cached all along; but actually, they weren't! After #4517 conditions really *are* cached, so anything which modifies `font.ttFont` also changes it for future tests. We need to make sure they're not doing that.

## Checklist
- [x] update `CHANGELOG.md` (not a noteworthy change - this is refactoring fallout)
- [x] wait for the tests to pass
- [x] request a review

