### PR TITLE
deprecate check.name field that was never used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.12.0a1 (2024-Feb-14)
   - Major refactoring. Check definitions now are all placed at `Lib/fontbakery/checks` and profile definitions are purely declarative, picking the checks from the pool by check-id. (PR #4491)
+  - Deprecate check.name field that was never used (issue #3478)
 
 ### New checks
 #### Added to the Google Fonts Profile

--- a/Lib/fontbakery/callable.py
+++ b/Lib/fontbakery/callable.py
@@ -174,9 +174,6 @@ class FontBakeryCheck(FontbakeryCallable):
         description: text, used as one line short description
         read by humans
 
-        name: text, used as a short label read by humans, defaults
-        to checkfunc.__name__
-
         conditions: a list of condition names that must be all true
         in order for this check to be executed. conditions are similar
         to checks, because they also inspect the check subject and they
@@ -200,7 +197,6 @@ class FontBakeryCheck(FontbakeryCallable):
         """
         super().__init__(checkfunc)
         self.id = id
-        self.name = checkfunc.__name__ if name is None else name
         self.conditions = conditions or []
         self.rationale = rationale
         self.description, self.documentation = get_doc_desc(


### PR DESCRIPTION
(issue #3478)
