### PR TITLE
OpenType spec does not impose single hyphen condition on postcript names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,22 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.12.0 (2024-Feb-??)
+  - And also includes the changes from the previous release-candidates:
+    - v0.12.0a1 (2024-Feb-14)
+    - v0.12.0a2 (2024-Feb-19)
+
+
+## 0.12.0a2 (2024-Feb-19)
   - **[multi-threading]:** Lock reporting when returning results. (issue #4494)
   - Added support for checking TTC (OpenType font collection) files. (issue #2595)
-  - And also includes the changes from the previous release-candidate v0.12.0a1 (2024-Feb-14)
 
 ### New checks
 #### Added to the Google Fonts profile
   - **EXPERIMENTAL - [com.google.fonts/check/metadata/minisite_url]:** Validate minisite_url field on METADATA.pb (issue #4504)
+
+### Changes to existing checks
+#### On the Open Type Profile
+  - **[com.adobe.fonts/check/postscript_name]:** OpenType spec does not impose single hyphen condition on postcript names. (issue #4348)
 
 
 ## 0.12.0a1 (2024-Feb-14)

--- a/Lib/fontbakery/checks/opentype/name.py
+++ b/Lib/fontbakery/checks/opentype/name.py
@@ -439,14 +439,6 @@ def com_adobe_fonts_check_postscript_name(ttFont):
                     ),
                 }
             )
-        if string.count("-") > 1:
-            bad_entries.append(
-                {
-                    "Field": "Postscript Name",
-                    "Value": string,
-                    "Recommendation": ("May contain not more than a single hyphen."),
-                }
-            )
 
     if len(bad_entries) > 0:
         yield FAIL, Message(

--- a/tests/checks/opentype/name_test.py
+++ b/tests/checks/opentype/name_test.py
@@ -654,19 +654,6 @@ def test_check_name_postscript():
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
     assert_PASS(check(ttFont))
 
-    # Change the PostScript name string to more than one hyphen. Should FAIL.
-    bad_ps_name = "more-than-one-hyphen".encode("utf-16-be")
-    ttFont["name"].setName(
-        bad_ps_name,
-        NameID.POSTSCRIPT_NAME,
-        PlatformID.WINDOWS,
-        WindowsEncodingID.UNICODE_BMP,
-        WindowsLanguageID.ENGLISH_USA,
-    )
-    msg = assert_results_contain(check(ttFont), FAIL, "bad-psname-entries")
-    assert "PostScript name does not follow requirements" in msg
-    assert "May contain not more than a single hyphen." in msg
-
     # Now change it to a string with illegal characters. Should FAIL.
     bad_ps_name = "(illegal) characters".encode("utf-16-be")
     ttFont["name"].setName(


### PR DESCRIPTION
(issue #4348)
