### PR TITLE
Deprecated font-v check and dropped font-v dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Google Fonts profile
   - **EXPERIMENTAL - [com.google.fonts/check/metadata/minisite_url]:** Validate minisite_url field on METADATA.pb (issue #4504)
 
+### Deprecated checks
+#### Removed from the Google Fonts profile
+  - **[com.google.fonts/check/font-v]:** (issue #4138)
+
 ### Changes to existing checks
 #### On the Open Type Profile
   - **[com.adobe.fonts/check/postscript_name]:** OpenType spec does not impose single hyphen condition on postcript names. (issue #4348)

--- a/Lib/fontbakery/checks/googlefonts/__init__.py
+++ b/Lib/fontbakery/checks/googlefonts/__init__.py
@@ -131,35 +131,3 @@ def com_google_fonts_check_fontdata_namecheck(ttFont, familyname):
             f"\t\tOriginal error message:\n"
             f"\t\t{sys.exc_info()[0]}",
         )
-
-
-@check(
-    id="com.google.fonts/check/fontv",
-    rationale="""
-        The git sha1 tagging and dev/release features of Source Foundry `font-v` tool
-        are awesome and we would love to consider upstreaming the approach into
-        fontmake someday. For now we only emit an INFO if a given font does not yet
-        follow the experimental versioning style, but at some point we may start
-        enforcing it.
-    """,
-    proposal="https://github.com/fonttools/fontbakery/issues/1563",
-)
-def com_google_fonts_check_fontv(ttFont):
-    """Check for font-v versioning."""
-    try:
-        from fontv.libfv import FontVersion
-    except ImportError:
-        exit_with_install_instructions()
-
-    fv = FontVersion(ttFont)
-    if fv.version and (fv.is_development or fv.is_release):
-        yield PASS, "Font version string looks GREAT!"
-    else:
-        yield INFO, Message(
-            "bad-format",
-            f'Version string is: "{fv.get_name_id5_version_string()}"\n'
-            f"The version string must ideally include a git commit hash"
-            f' and either a "dev" or a "release" suffix such as in the'
-            f" example below:\n"
-            f'"Version 1.3; git-0d08353-release"',
-        )

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -110,7 +110,6 @@ PROFILE = {
             "com.google.fonts/check/vendor_id",
             "com.google.fonts/check/ligature_carets",
             "com.google.fonts/check/production_glyphs_similarity",
-            "com.google.fonts/check/fontv",
             # DISABLED: "com.google.fonts/check/production_encoded_glyphs",
             "com.google.fonts/check/glyf_nested_components",
             "com.google.fonts/check/varfont/generate_static",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ collidoscope==0.6.5
 defcon==0.10.3
 dehinter==4.0.0
 fontTools[ufo,lxml,unicode]==4.48.1
-font-v==2.1.0
 freetype-py==2.3.0  # pinned for now. See: https://github.com/fonttools/fontbakery/issues/4143
 gflanguages==0.5.17
 gfsubsets==2024.2.5

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,6 @@ googlefonts_extras = (
     [
         f"beautifulsoup4{BEAUTIFULSOUP4_VERSION}",
         "dehinter>=3.1.0",  # 3.1.0 added dehinter.font.hint function
-        "font-v>=0.6.0",  # com.google.fonts/check/fontv produces an ERROR with font-v
-        # version 0.5.0 or earlier because it uses the method
-        # FontVersion.get_name_id5_version_string which was added in version 0.6.0
         f"fontTools[lxml,unicode]{FONTTOOLS_VERSION}",
         # (see https://github.com/googlefonts/gflanguages/pull/7)
         "protobuf>=3.7.0, <4",  # 3.7.0 fixed a bug on parsing some METADATA.pb files.

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -3035,30 +3035,6 @@ def test_check_fontdata_namecheck():
     assert_PASS(check(font), "with a unique family name...", ignore_error=TIMEOUT_MSG)
 
 
-def test_check_fontv():
-    """Check for font-v versioning"""
-    check = CheckTester("com.google.fonts/check/fontv")
-
-    ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
-    assert_results_contain(
-        check(ttFont),
-        INFO,
-        "bad-format",
-        "with a font that does not follow"
-        " the suggested font-v versioning scheme ...",
-    )
-
-    from fontv.libfv import FontVersion
-
-    fv = FontVersion(ttFont)
-    fv.set_state_git_commit_sha1(development=True)
-    version_string = fv.get_name_id5_version_string()
-    for record in ttFont["name"].names:
-        if record.nameID == NameID.VERSION_STRING:
-            record.string = version_string
-    assert_PASS(check(ttFont), "with one that follows the suggested scheme ...")
-
-
 def test_check_glyf_nested_components():
     """Check glyphs do not have nested components."""
     check = CheckTester("com.google.fonts/check/glyf_nested_components")


### PR DESCRIPTION
**com.google.fonts/check/font-v**

Removed from the Google Fonts profile

(issue #4138)
