### PR TITLE
Accept private feature tags on check/layout_valid_feature_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a1 (2024-Feb-14)
     - v0.12.0a2 (2024-Feb-21)
 
+### Changes to existing checks
+#### On the Open Type Profile
+  - **[com.google.fonts/check/layout_valid_feature_tags]:** Updated the check to allow valid private-use feature tags. (issue #4544)
+
 
 ## 0.12.0a2 (2024-Feb-21)
   - **[multi-threading]:** Lock reporting when returning results. (issue #4494)

--- a/Lib/fontbakery/checks/layout.py
+++ b/Lib/fontbakery/checks/layout.py
@@ -23,6 +23,9 @@ DEPRECATED_TAGS = ["hngl", "opbd", "size"]
         Incorrect tags can be indications of typos, leftover debugging code or
         questionable approaches, or user error in the font editor. Such typos can
         cause features and language support to fail to work as intended.
+
+        Font vendors may use private tags to identify private features. These tags
+        must be four uppercase letters (A-Z) with no punctuation, spaces, or numbers.
     """,
     proposal="https://github.com/fonttools/fontbakery/issues/3355",
     severity=8,
@@ -39,7 +42,8 @@ def com_google_fonts_check_layout_valid_feature_tags(ttFont):
     bad_tags = set()
     for tag in feature_tags(ttFont):
         if tag not in acceptable_tags:
-            bad_tags.add(tag)
+            if not tag.isupper() or len(tag) > 4:
+                bad_tags.add(tag)
     if bad_tags:
         yield FAIL, Message(
             "bad-feature-tags",

--- a/tests/checks/layout_test.py
+++ b/tests/checks/layout_test.py
@@ -1,3 +1,4 @@
+from fontTools.ttLib import TTFont
 from fontbakery.status import FAIL
 from fontbakery.codetesting import (
     assert_PASS,
@@ -11,9 +12,17 @@ def test_check_layout_valid_feature_tags():
     """Does the font have any invalid feature tags?"""
     check = CheckTester("com.google.fonts/check/layout_valid_feature_tags")
 
+    # test font with valid, registered feature tags.
     font = TEST_FILE("nunito/Nunito-Regular.ttf")
     assert_PASS(check(font))
 
+    # test font with valid, private use feature tags.
+    # change font's feature tag to have non-registered, all uppercase private tags
+    font_obj = TTFont(font)
+    font_obj["GSUB"].table.FeatureList.FeatureRecord[0].FeatureTag = "TEST"
+    assert_PASS(check(font_obj))
+
+    # test font with invalid feature tags: not registered, and not all uppercase.
     font = TEST_FILE("rosarivo/Rosarivo-Regular.ttf")
     assert_results_contain(check(font), FAIL, "bad-feature-tags")
 


### PR DESCRIPTION
Updated the check to allow valid private-use feature tags.

On the Open Type Profile
**com.google.fonts/check/layout_valid_feature_tags**

Ported from Open Bakery.

(issue #4544)