### PR TITLE
Generate check-level documentation with Sphinx

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt -r requirements-tests.txt
+        python -m pip install -r requirements.txt -r requirements-tests.txt -r requirements-docs.txt
         python -m pip install pytype # Not in requirements as it doesn't work on Windows
 
     - name: Run black, pylint and pytype

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt -r requirements-tests.txt
+        python -m pip install -r requirements.txt -r requirements-tests.txt -r requirements-docs.txt
         python -m pip freeze --all
 
     - name: Install FontBakery
@@ -86,3 +86,7 @@ jobs:
       run: |
         python -m pytest --quiet --cov
 
+    - name: Ensure documentation can build (only Ubuntu/Python 3.10)
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+      run: |
+        cd docs; make html

--- a/Lib/fontbakery/checks/googlefonts/gdef.py
+++ b/Lib/fontbakery/checks/googlefonts/gdef.py
@@ -34,7 +34,7 @@ def ligature_glyphs(font):
         caret rendering.
 
         If using GlyphsApp or UFOs, ligature carets can be defined as anchors with
-        names starting with 'caret_'. These can be compiled with fontmake as of
+        names starting with `caret_`. These can be compiled with fontmake as of
         version v2.4.0.
     """,
     proposal="https://github.com/fonttools/fontbakery/issues/1225",

--- a/Lib/fontbakery/checks/googlefonts/varfont.py
+++ b/Lib/fontbakery/checks/googlefonts/varfont.py
@@ -295,13 +295,13 @@ def com_google_fonts_check_varfont_consistent_axes(VFs):
 
         The target font will be the mean of each axis e.g:
 
-        ## VF font axes
+        **VF font axes**
 
         - min weight, max weight = 400, 800
 
         - min width, max width = 50, 100
 
-        ## Target Instance
+        **Target Instance**
 
         - weight = 600
 

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -1168,8 +1168,8 @@ def com_google_fonts_check_STAT_strings(ttFont):
 
         'NOTE: The PostScript glyph name must be no longer than 31 characters,
         include only uppercase or lowercase English letters, European digits,
-        the period or the underscore, i.e. from the set [A-Za-z0-9_.] and
-        should start with a letter, except the special glyph name ".notdef"
+        the period or the underscore, i.e. from the set `[A-Za-z0-9_.]` and
+        should start with a letter, except the special glyph name `.notdef`
         which starts with a period.'
 
         https://learn.microsoft.com/en-us/typography/opentype/otspec181/recom#-post--table

--- a/Lib/fontbakery/sphinx_extensions/profile.py
+++ b/Lib/fontbakery/sphinx_extensions/profile.py
@@ -59,7 +59,7 @@ class FontbakeryProfileDocumenter(ModuleDocumenter):
                         )
                         self.add_line(
                             f"    - The **{code}** result is reported as a"
-                            " **{status}** in this profile",
+                            f" **{status}** in this profile",
                             source_name,
                         )
                         if reason:

--- a/docs/source/developer/source-contrib-guide.rst
+++ b/docs/source/developer/source-contrib-guide.rst
@@ -103,7 +103,7 @@ suite of checks. We aim to reach 100% test coverage.
 In order to run the tests you need to have the ``pytest`` dependency installed.
 
 Install ``pytest``
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Install ``pytest`` in your virtual environment with:
 

--- a/docs/source/fontbakery/checks/adobefonts.rst
+++ b/docs/source/fontbakery/checks/adobefonts.rst
@@ -1,0 +1,6 @@
+#########################################
+Checks to support the Adobe Fonts profile
+#########################################
+
+.. automodule:: fontbakery.checks.adobefonts
+    :members:

--- a/docs/source/fontbakery/checks/fontbureau.rst
+++ b/docs/source/fontbakery/checks/fontbureau.rst
@@ -1,0 +1,6 @@
+########################################
+Checks to support the Fontbureau profile
+########################################
+
+.. automodule:: fontbakery.checks.fontbureau
+    :members:

--- a/docs/source/fontbakery/checks/fontval.rst
+++ b/docs/source/fontbakery/checks/fontval.rst
@@ -1,0 +1,6 @@
+############################################
+Checks to support the Font Validator profile
+############################################
+
+.. automodule:: fontbakery.checks.fontval
+    :members:

--- a/docs/source/fontbakery/checks/fontwerk.rst
+++ b/docs/source/fontbakery/checks/fontwerk.rst
@@ -1,0 +1,6 @@
+######################################
+Checks to support the Fontwerk profile
+######################################
+
+.. automodule:: fontbakery.checks.fontwerk
+    :members:

--- a/docs/source/fontbakery/checks/googlefonts.rst
+++ b/docs/source/fontbakery/checks/googlefonts.rst
@@ -1,0 +1,153 @@
+##########################################
+Checks to support the Google Fonts profile
+##########################################
+
+Base checks
+***********
+
+.. automodule:: fontbakery.checks.googlefonts
+    :members:
+
+Axis registry checks
+********************
+
+.. automodule:: fontbakery.checks.googlefonts.axisregistry
+    :members:
+
+Color font checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.color
+    :members:
+
+Copyright checks
+****************
+
+.. automodule:: fontbakery.checks.googlefonts.copyright
+    :members:
+
+Description checks
+******************
+
+.. automodule:: fontbakery.checks.googlefonts.description
+    :members:
+
+Family checks
+*************
+
+.. automodule:: fontbakery.checks.googlefonts.family
+    :members:
+
+GDEF table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.gdef
+    :members:
+
+glyf table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.glyf
+    :members:
+
+Glyphset checks
+***************
+
+.. automodule:: fontbakery.checks.googlefonts.glyphset
+    :members:
+
+GPOS table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.gpos
+    :members:
+
+GSUB table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.gsub
+    :members:
+
+head table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.head
+    :members:
+
+Hinting checks
+**************
+
+.. automodule:: fontbakery.checks.googlefonts.hinting
+    :members:
+
+Regressions checks against fonts hosted on fonts.google.com
+***********************************************************
+
+.. automodule:: fontbakery.checks.googlefonts.hosted
+    :members:
+
+License checks
+**************
+
+.. automodule:: fontbakery.checks.googlefonts.license
+    :members:
+
+meta table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.meta
+    :members:
+
+Metadata checks
+***************
+
+.. automodule:: fontbakery.checks.googlefonts.metadata
+    :members:
+
+name table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.name
+    :members:
+
+OS/2 table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.os2
+    :members:
+
+Repository checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.repo
+    :members:
+
+STAT table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.stat
+    :members:
+
+Subsetting checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.subsets
+    :members:
+
+Font table checks
+*****************
+
+.. automodule:: fontbakery.checks.googlefonts.tables
+    :members:
+
+Variable font checks
+********************
+
+.. automodule:: fontbakery.checks.googlefonts.varfont
+    :members:
+
+Vertical metrics checks
+***********************
+
+.. automodule:: fontbakery.checks.googlefonts.vmetrics
+    :members:

--- a/docs/source/fontbakery/checks/index.rst
+++ b/docs/source/fontbakery/checks/index.rst
@@ -1,0 +1,20 @@
+#################
+Check definitions
+#################
+
+.. toctree::
+   :maxdepth: 1
+
+   adobefonts
+   fontbureau
+   fontval
+   fontwerk
+   googlefonts
+   iso15008
+   notofonts
+   opentype
+   outline
+   shaping
+   typenetwork
+   ufo
+   universal

--- a/docs/source/fontbakery/checks/iso15008.rst
+++ b/docs/source/fontbakery/checks/iso15008.rst
@@ -1,0 +1,6 @@
+######################################
+Checks to support the ISO15008 profile
+######################################
+
+.. automodule:: fontbakery.checks.iso15008
+    :members:

--- a/docs/source/fontbakery/checks/notofonts.rst
+++ b/docs/source/fontbakery/checks/notofonts.rst
@@ -1,0 +1,6 @@
+########################################
+Checks to support the Noto fonts profile
+########################################
+
+.. automodule:: fontbakery.checks.notofonts
+    :members:

--- a/docs/source/fontbakery/checks/opentype.rst
+++ b/docs/source/fontbakery/checks/opentype.rst
@@ -1,0 +1,105 @@
+######################################################
+Checks for conformance with the OpenType specification
+######################################################
+
+Base checks
+***********
+
+.. automodule:: fontbakery.checks.opentype
+    :members:
+
+CFF table checks
+****************
+
+.. automodule:: fontbakery.checks.opentype.cff
+    :members:
+
+cmap table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.cmap
+    :members:
+
+DSIG table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.dsig
+    :members:
+
+fvar table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.fvar
+    :members:
+
+GDEF table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.gdef
+    :members:
+
+glyf table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.glyf
+    :members:
+
+GPOS table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.gpos
+    :members:
+
+head table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.head
+    :members:
+
+hhea table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.hhea
+    :members:
+
+kern table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.kern
+    :members:
+
+Layout-related checks
+*********************
+
+.. automodule:: fontbakery.checks.opentype.layout
+    :members:
+
+loca table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.loca
+    :members:
+
+name table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.name
+    :members:
+
+OS/2 table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.os2
+    :members:
+
+post table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.post
+    :members:
+
+STAT table checks
+*****************
+
+.. automodule:: fontbakery.checks.opentype.stat
+    :members:

--- a/docs/source/fontbakery/checks/outline.rst
+++ b/docs/source/fontbakery/checks/outline.rst
@@ -1,0 +1,6 @@
+################################
+Checks related to glyph outlines
+################################
+
+.. automodule:: fontbakery.checks.outline
+    :members:

--- a/docs/source/fontbakery/checks/shaping.rst
+++ b/docs/source/fontbakery/checks/shaping.rst
@@ -1,0 +1,6 @@
+##############################################
+Checks for shaping regression tests and errors
+##############################################
+
+.. automodule:: fontbakery.checks.shaping
+    :members:

--- a/docs/source/fontbakery/checks/typenetwork.rst
+++ b/docs/source/fontbakery/checks/typenetwork.rst
@@ -1,0 +1,6 @@
+##########################################
+Checks to support the Type Network profile
+##########################################
+
+.. automodule:: fontbakery.checks.typenetwork
+    :members:

--- a/docs/source/fontbakery/checks/ufo.rst
+++ b/docs/source/fontbakery/checks/ufo.rst
@@ -1,0 +1,6 @@
+##########################
+Checks on UFO source files
+##########################
+
+.. automodule:: fontbakery.checks.ufo
+    :members:

--- a/docs/source/fontbakery/checks/universal.rst
+++ b/docs/source/fontbakery/checks/universal.rst
@@ -1,0 +1,6 @@
+#########################################################
+Checks for commonly agreed font production best practices
+#########################################################
+
+.. automodule:: fontbakery.checks.universal
+    :members:

--- a/docs/source/fontbakery/index.rst
+++ b/docs/source/fontbakery/index.rst
@@ -8,6 +8,7 @@ A single-page index of all source modules is available in :ref:`modindex`.
    :maxdepth: 1
 
    callable
+   checks/index
    checkrunner
    cli
    commands/index

--- a/docs/source/user/USAGE.md
+++ b/docs/source/user/USAGE.md
@@ -1,4 +1,4 @@
-## Font Bakery Command Line Usage
+# Font Bakery Command Line Usage
 
 Install Font Bakery as a package with the instructions in the [Installation Guides](https://font-bakery.readthedocs.io/en/stable/user/installation/index.html), and you will have a `fontbakery` command in your `$PATH`.
 
@@ -33,7 +33,7 @@ This has several subcommands, described in the help function:
                           by a space character. This is usually only used to 
                           generate the shell completion code.
 
-### fontbakery check-universal
+## fontbakery check-universal
 
 The "universal" profile contains checks for best practices agreed upon on the type design community.
 
@@ -43,11 +43,11 @@ The goal is to keep the vendor-specific profiles with only the minimal set of ch
 
 We should always consider contributing new checks (or moving existing ones) to this universal profile, if appropriate.
 
-### fontbakery check-adobefonts / check-fontbureau / check-fontwerk / check-notofonts
+## fontbakery check-adobefonts / check-fontbureau / check-fontwerk / check-notofonts
 
 Usage is analogous to the Google Fonts profile described below.
 
-### fontbakery check-googlefonts
+## fontbakery check-googlefonts
 
 This is the command used by foundries checking their projects for Google Fonts 
 
@@ -165,13 +165,13 @@ For checking the GFonts collection the script is used like this:
 
 This will create a folder called `check_results/` then run the `check-googlefonts` subcommand on every family, saving individual per-family reports in json format into subdirectories.
 
-### fontbakery check-fontval
+## fontbakery check-fontval
 
 This is a wrapper around the Microsoft Font Validator.
 
 Usage is similar to the check-googlefonts command described above.
 
-### Configuration file
+## Configuration file
 
 Some command-line parameters can be configured in a configuration file.
 This may be in TOML or YAML format, and the name of this file is passed in

--- a/docs/source/user/bash-completion.md
+++ b/docs/source/user/bash-completion.md
@@ -1,4 +1,4 @@
-### Bash Completion
+# Bash Completion
 
 Font Bakery comes with a minimal Bash completion script to help you to type the subcommands that follow directly after the `fontbakery` command by hitting the tab key.
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,5 @@
 sphinx == 7.2.6
 sphinx_rtd_theme == 2.0.0
 myst-parser == 2.0.0
+m2r == 0.3.1
 -e .[all]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-sphinx == 7.2.6
+sphinx == 7.1.2
 sphinx_rtd_theme == 2.0.0
 myst-parser == 2.0.0
 m2r == 0.3.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,5 @@
 --index-url https://pypi.python.org/simple/
 black==23.12.1
 pylint==3.0.3
-sphinx==7.1.2  # Sphinx 7.2.x series requires python >= 3.9
 pytest-cov==4.1.0
 pytest-xdist==3.5.0


### PR DESCRIPTION
This allows Sphinx to render information about checks (again) in the Sphinx/RTD pages. Once we have it actually building again, I'll hook up the metadata reporter.

<img width="774" alt="Screenshot 2024-02-23 at 12 46 01" src="https://github.com/fonttools/fontbakery/assets/106728/15a21168-343a-4ae6-899c-85f724fc6a40">
