### PR TITLE
com.google.fonts/check/mac_style: Skip if font.style is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Open Type Profile
   - **[com.google.fonts/check/layout_valid_feature_tags]:** Updated the check to allow valid private-use feature tags. (issue #4544)
   - **[com.google.fonts/check/varfont/family_axis_ranges]:** Updated the check to skip fonts without fvar tables. (issue #4554)
+  - **[com.google.fonts/check/mac_style]:** Skip if font style can not be determined. (issue #4349)
 
 
 ## 0.12.0a2 (2024-Feb-21)

--- a/Lib/fontbakery/checks/opentype/head.py
+++ b/Lib/fontbakery/checks/opentype/head.py
@@ -1,7 +1,7 @@
 import fractions
 
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS, WARN
+from fontbakery.status import FAIL, PASS, WARN, SKIP
 from fontbakery.message import Message
 from fontbakery.constants import NameID
 
@@ -190,6 +190,10 @@ def com_google_fonts_check_mac_style(font):
     """Checking head.macStyle value."""
     from fontbakery.utils import check_bit_entry
     from fontbakery.constants import MacStyle
+
+    if font.style is None:
+        yield SKIP, "Font style could not be determined."
+        return
 
     # Checking macStyle ITALIC bit:
     expected = "Italic" in font.style

--- a/Lib/fontbakery/checks/opentype/head.py
+++ b/Lib/fontbakery/checks/opentype/head.py
@@ -1,7 +1,7 @@
 import fractions
 
 from fontbakery.callable import check
-from fontbakery.status import FAIL, PASS, WARN, SKIP
+from fontbakery.status import FAIL, PASS, WARN
 from fontbakery.message import Message
 from fontbakery.constants import NameID
 
@@ -184,16 +184,13 @@ def com_google_fonts_check_font_version(ttFont):
         that describe whether a font is bold and/or italic must be coherent with the
         actual style of the font as inferred by its filename.
     """,
+    conditions=["style"],
     proposal="legacy:check/131",
 )
 def com_google_fonts_check_mac_style(font):
     """Checking head.macStyle value."""
     from fontbakery.utils import check_bit_entry
     from fontbakery.constants import MacStyle
-
-    if font.style is None:
-        yield SKIP, "Font style could not be determined."
-        return
 
     # Checking macStyle ITALIC bit:
     expected = "Italic" in font.style

--- a/tests/checks/opentype/head_test.py
+++ b/tests/checks/opentype/head_test.py
@@ -1,9 +1,10 @@
 from fontTools.ttLib import TTFont
 import pytest
 
-from fontbakery.status import WARN, FAIL, PASS
+from fontbakery.status import WARN, FAIL, PASS, SKIP
 from fontbakery.codetesting import (
     assert_PASS,
+    assert_SKIP,
     assert_results_contain,
     CheckTester,
     TEST_FILE,
@@ -194,6 +195,7 @@ def test_check_mac_style():
         [MacStyle.BOLD, "Bold", PASS],
         [MacStyle.BOLD, "Thin", "bad-BOLD"],
         [MacStyle.BOLD | MacStyle.ITALIC, "BoldItalic", PASS],
+        [0, None, SKIP],
     ]
 
     for macStyle_value, style, expected in test_cases:
@@ -201,6 +203,11 @@ def test_check_mac_style():
 
         if expected == PASS:
             assert_PASS(
+                check(MockFont(ttFont=ttFont, style=style)),
+                "with macStyle:{macStyle_value} style:{style}...",
+            )
+        elif expected == SKIP:
+            assert_SKIP(
                 check(MockFont(ttFont=ttFont, style=style)),
                 "with macStyle:{macStyle_value} style:{style}...",
             )


### PR DESCRIPTION
If `font.style` is None, the test currently errors.

Related to https://github.com/fonttools/fontbakery/issues/4349, but not a complete fix.

(Provide a list of all the noteworthy changes you've done. Elaborate on any decisions you had to make, and include links and/or screenshots, if applicable)

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

