### PR TITLE
Speed up start

### DIFF
--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -113,7 +113,7 @@ class CheckRunner:
 
     def _get(self, name, iterargs, condition=False):
         # Is this a property of the whole collection?
-        if hasattr(self.context, name):
+        if name in dir(self.context):
             return getattr(self.context, name)
         # Is it a property of the file we're testing?
         for thing, index in iterargs:
@@ -121,7 +121,7 @@ class CheckRunner:
             # Allow "font" to return the Font object itself
             if name == thing:
                 return specific_thing
-            if not hasattr(specific_thing, name):
+            if name not in dir(specific_thing):
                 continue
             return getattr(specific_thing, name)
         if condition:
@@ -243,7 +243,7 @@ class CheckRunner:
                 ):
                     continue
                 args = set(check.args)
-                context_args = set(arg for arg in args if hasattr(self.context, arg))
+                context_args = set(arg for arg in args if arg in dir(self.context))
 
                 # Either this is a check which runs on the whole collection
                 # (i.e. all of its arguments can be called as methods on the
@@ -257,7 +257,7 @@ class CheckRunner:
                     individual_args = args - context_args
                     if (
                         all(
-                            hasattr(file, arg)
+                            arg in dir(file)
                             for arg in individual_args
                             for file in files
                         )

--- a/Lib/fontbakery/codetesting.py
+++ b/Lib/fontbakery/codetesting.py
@@ -51,6 +51,9 @@ def make_mock(basecls, name):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
+    def __dir__(self):
+        return dir(basecls) + list(self.__dict__.keys())
+
     def __getattr__(self, name):
         prop = getattr(basecls, name)
         if isinstance(prop, cached_property):
@@ -61,6 +64,7 @@ def make_mock(basecls, name):
 
     cls.__init__ = __init__
     cls.__getattr__ = __getattr__
+    cls.__dir__ = __dir__
     cls.mocked = True
     return cls
 


### PR DESCRIPTION
We currently use `hasattr` to determine what conditions are available on a testable (file or whole collection), to see whether or not to route a testable to a check. For a cached property, `hasattr` *[actually gets the value](https://stackoverflow.com/questions/30143957/why-does-hasattr-execute-the-property-decorator-code-block) of the property*! `dir()` does not, so we use that instead, although it requires a little bit of tweaking to the mock object.

I'm not sure this actually makes fontbakery faster, but it certainly makes it *feel* faster, because we do the network conditions etc. when they are used, not at startup...