### PR TITLE
Refactor markdown reporter

### DIFF
--- a/Lib/fontbakery/commands/check_profile.py
+++ b/Lib/fontbakery/commands/check_profile.py
@@ -26,7 +26,7 @@ from fontbakery.fonts_profile import (
     ITERARGS,
 )
 from fontbakery.reporters.terminal import TerminalReporter
-from fontbakery.reporters.serialize import SerializeReporter
+from fontbakery.reporters.serialize import JSONReporter
 from fontbakery.reporters.badge import BadgeReporter
 from fontbakery.reporters.ghmarkdown import GHMarkdownReporter
 from fontbakery.reporters.html import HTMLReporter
@@ -214,7 +214,7 @@ def ArgumentParser(profile_arg=True):
         "--json",
         default=False,
         action=AddReporterAction,
-        cls=SerializeReporter,
+        cls=JSONReporter,
         metavar="JSON_FILE",
         help="Write a json formatted report to JSON_FILE.",
     )

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -8,15 +8,7 @@ LOGLEVELS = ["ERROR", "FATAL", "FAIL", "WARN", "SKIP", "INFO", "PASS", "DEBUG"]
 
 
 class GHMarkdownReporter(SerializeReporter):
-    def write(self):
-        with open(self.output_file, "w", encoding="utf8") as fh:
-            fh.write(self.get_markdown())
-        if not self.quiet:
-            print(
-                f"A report in GitHub Markdown format which can be useful\n"
-                f" for posting issues on a GitHub issue tracker has been\n"
-                f' saved to "{self.output_file}"'
-            )
+    format = "GitHub Markdown"
 
     @staticmethod
     def emoticon(name):
@@ -82,12 +74,11 @@ class GHMarkdownReporter(SerializeReporter):
         first_check = cluster[0]
         return all(check["logs"] == first_check["logs"] for check in cluster[1:])
 
-    def get_markdown(self):
+    def template(self, data):
         fatal_checks = {}
         experimental_checks = {}
         other_checks = {}
 
-        data = self.getdoc()
         num_checks = 0
         for section in data["sections"]:
             for cluster in section["checks"]:

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -54,13 +54,14 @@ class GHMarkdownReporter(SerializeReporter):
 
     def check_md(self, check):
         checkid = check["key"][1].split(":")[1].split(">")[0]
-        profile = check["profile"]
+        module = check["module"].split(".")[0]  # opentype/fvar.py -> opentype.html
 
         check["logs"].sort(key=lambda c: c["status"])
         logs = "".join(map(self.log_md, check["logs"]))
+        anchor = checkid.replace("_", "-").replace("/", "-").replace(".", "-")
         github_search_url = (
-            '<a href="https://font-bakery.readthedocs.io/en/stable'
-            f'/fontbakery/profiles/{profile}.html#{checkid}">'
+            '<a href="https://fontbakery.readthedocs.io/en/stable'
+            f'/fontbakery/checks/{module}.html#{anchor}">'
             f"{checkid}</a>"
         )
 

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -78,26 +78,6 @@ class GHMarkdownReporter(SerializeReporter):
         )
 
     @staticmethod
-    def deduce_profile_from_section_name(section):
-        # This is very hacky!
-        # We should have a much better way of doing it...
-        if "Google Fonts" in section:
-            return "googlefonts"
-        if "Adobe" in section:
-            return "adobefonts"
-        if "Font Bureau" in section:
-            return "fontbureau"
-        if "Universal" in section:
-            return "universal"
-        if "Basic UFO checks" in section:
-            return "ufo_sources"
-        if "Checks inherited from Microsoft Font Validator" in section:
-            return "fontval"
-        if "fontbakery.profiles." in section:
-            return section.split("fontbakery.profiles.")[1].split(">")[0]
-        return section
-
-    @staticmethod
     def result_is_all_same(cluster):
         first_check = cluster[0]
         return all(check["logs"] == first_check["logs"] for check in cluster[1:])
@@ -123,10 +103,6 @@ class GHMarkdownReporter(SerializeReporter):
                 for check in cluster:
                     if self.omit_loglevel(check["result"]):
                         continue
-                    check["profile"] = self.deduce_profile_from_section_name(
-                        section["key"][0]
-                    )
-
                     if "filename" in check.keys():
                         key = os.path.basename(check["filename"])
                     else:

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -44,16 +44,10 @@ def markdown(message):
 
 class HTMLReporter(SerializeReporter):
     """Renders a report as a HTML document."""
+    format = "HTML"
 
-    def write(self):
-        with open(self.output_file, "w", encoding="utf-8") as fh:
-            fh.write(self.get_html())
-        if not self.quiet:
-            print(f'A report in HTML format has been saved to "{self.output_file}"')
-
-    def get_html(self) -> str:
+    def template(self, data) -> str:
         """Returns complete report as a HTML string."""
-        data = self.getdoc()
         total = 0
         loaders = [PackageLoader("fontbakery.reporters", "templates/html")]
         try:

--- a/Lib/fontbakery/reporters/serialize.py
+++ b/Lib/fontbakery/reporters/serialize.py
@@ -15,13 +15,7 @@ from fontbakery.reporters import FontbakeryReporter
 
 
 class SerializeReporter(FontbakeryReporter):
-    """
-    usage:
-    >> sr = SerializeReporter(runner=runner, collect_results_by='font')
-    >> sr.run()
-    >> import json
-    >> print(json.dumps(sr.getdoc(), sort_keys=True, indent=4))
-    """
+    format = "unknown"
 
     def __post_init__(self):
         super().__post_init__()
@@ -59,9 +53,23 @@ class SerializeReporter(FontbakeryReporter):
         }
 
     def write(self):
+        with open(self.output_file, "w", encoding="utf-8") as fh:
+            fh.write(self.template(self.getdoc()))
+        if not self.quiet:
+            print(
+                f'A report in {self.format} format has been saved to "{self.output_file}"'
+            )
+
+    def template(self, _data):
+        raise NotImplementedError(
+            "Subclasses of SerializeReporter must implement the template method"
+        )
+
+
+class JSONReporter(SerializeReporter):
+    format = "JSON"
+
+    def template(self, doc):
         import json
 
-        with open(self.output_file, "w", encoding="utf-8") as fh:
-            json.dump(self.getdoc(), fh, sort_keys=True, indent=4)
-        if not self.quiet:
-            print(f'A report in JSON format has been saved to "{self.output_file}"')
+        return json.dumps(doc, sort_keys=True, indent=4)

--- a/Lib/fontbakery/reporters/templates/markdown/check.markdown
+++ b/Lib/fontbakery/reporters/templates/markdown/check.markdown
@@ -1,0 +1,17 @@
+<details>
+    <summary>{{check.result | emoticon}} **{{check.result}}** {{check.description}} <a href="https://fontbakery.readthedocs.io/en/stable/fontbakery/checks/{{check.module}}.html#{{check.id | replace("_", "-") | replace("/", "-") | replace(".", "-")}}">{{check.id}}</a></summary>
+    <div>
+
+{% if not succinct %}
+{% for line in check.rationale.split("\n") %}> {{line | unwrap | replace("\n", "") }}
+{% endfor %}
+{% endif %}
+
+{% for result in check.logs |sort(attribute="status") %}
+{% if not result is omitted %}
+* {{result.status | emoticon }} **{{result.status}}** {{result.message.message}} {%if result.message.code%}[code: {{result.message.code}}]{%endif%}
+{% endif %}
+{% endfor %}
+
+</div>
+</details>

--- a/Lib/fontbakery/reporters/templates/markdown/checks.markdown
+++ b/Lib/fontbakery/reporters/templates/markdown/checks.markdown
@@ -1,0 +1,8 @@
+<details>
+    <summary>[{{checks |length}}] {{filename}}</summary>
+    <div>
+        {% for check in checks %}
+        {% include "check.markdown" %}
+        {% endfor %}
+    </div>
+</details>

--- a/Lib/fontbakery/reporters/templates/markdown/main.markdown
+++ b/Lib/fontbakery/reporters/templates/markdown/main.markdown
@@ -1,0 +1,49 @@
+## FontBakery report
+
+fontbakery version: {{fb_version}}
+
+{% if fatal_checks %}
+## Checks with FATAL results
+
+These must be addressed first.
+
+{% for filename, checks in fatal_checks.items() %}
+{% include "checks.markdown" %}
+{% endfor %}
+{% endif %}
+{% if experimental_checks %}
+## Experimental checks
+
+These won't break the CI job for now, but will become effective after some time if nobody raises any concern.
+
+{% for filename, checks in experimental_checks.items() %}
+{% include "checks.markdown" %}
+{% endfor %}
+{% endif %}
+{% if other_checks %}
+{% if experimental_checks or fatal_checks %}
+## All other checks
+{% else %}
+## Check results
+{% endif %}
+
+{% for filename, checks in other_checks.items() %}
+{% include "checks.markdown" %}
+{% endfor %}
+{% endif %}
+
+{% if total > 0 %}
+### Summary
+
+| {%for level in summary.keys() %}{{level | emoticon }} {{level}} | {%endfor%} |
+|---|---|
+| {%for level in summary.keys() %}{{summary[level]}} | {%endfor%} |
+| {%for level in summary.keys() %}{{summary[level] | percent_of(total )}} | {%endfor%} |
+{% endif %}
+
+{% if omitted %}
+**Note:** The following loglevels were omitted in this report:
+
+{% for level in omitted %}
+* {{level}}{% endfor %}
+{% endif %}

--- a/Lib/fontbakery/result.py
+++ b/Lib/fontbakery/result.py
@@ -74,6 +74,7 @@ class CheckResult:
     def getData(self, runner):
         """Return the result as a dictionary with data suitable for serialization."""
         check = self.identity.check
+        module = check.__module__.replace("fontbakery.checks.", "")
         json = {
             "key": self.identity.key,
             "description": check.description,
@@ -82,6 +83,7 @@ class CheckResult:
             "experimental": check.experimental,
             "severity": check.severity,
             "result": self.summary_status.name,
+            "module": module,
             "logs": [],
         }
         # This is a big hack

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -124,11 +124,6 @@ def unindent_and_unwrap_rationale(rationale, checkid=None):
     return f"\n{content.strip()}\n"
 
 
-def html5_collapsible(summary, details) -> str:
-    """Return nestable, collapsible <detail> tag for check grouping and sub-results."""
-    return f"<details><summary>{summary}</summary><div>{details}</div></details>"
-
-
 def split_camel_case(camelcase):
     chars = []
     for i, char in enumerate(camelcase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,6 @@ from fontbakery.utils import (
     exit_with_install_instructions,
     get_apple_terminal_bg_color,
     get_theme,
-    html5_collapsible,
     is_negated,
     pretty_print_list,
     split_camel_case,
@@ -172,13 +171,6 @@ def test_unindent_and_unwrap_rationale():
         "\n"
     )
     assert unindent_and_unwrap_rationale(rationale) == expected_rationale
-
-
-def test_html5_collapsible():
-    assert (
-        html5_collapsible("abc", "ABC")
-        == "<details><summary>abc</summary><div>ABC</div></details>"
-    )
 
 
 def test_split_camel_case():


### PR DESCRIPTION
This PR:

* Fixes the links to readthedocs in Markdown reports (#4540)
* Splits the generic Serialize and (new) specific JSON reporter
* Shares more code between the Serialize, HTML and Markdown reporters
* Allows Markdown reports to be templated, moving the Markdown out of Python code and into template files