### PR TITLE
Improve Markdown/HTML reports

### DIFF
--- a/Lib/fontbakery/reporters/templates/html/check.html
+++ b/Lib/fontbakery/reporters/templates/html/check.html
@@ -9,7 +9,17 @@
 {% if cluster[0].rationale and not succinct %}
     {{ cluster[0].rationale | unwrap | markdown }}
 {% endif %}
-
+{% if cluster[0].proposal and not succinct %}
+    <ul>
+    {% for proposal in cluster[0].proposal %}
+        {% if loop.index == 1 %}
+            <li>Original proposal: <a href="{{proposal}}">{{proposal}}</a></li>
+        {% else %}
+            <li>See also: <a href="{{proposal}}">{{proposal}}</a></li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+{% endif %}
 <div style="background-color:#ee8">
 {% for check in cluster %}
     {% if check['result'] == "FATAL" %}

--- a/Lib/fontbakery/reporters/templates/markdown/check.markdown
+++ b/Lib/fontbakery/reporters/templates/markdown/check.markdown
@@ -2,7 +2,7 @@
     <summary>{{check.result | emoticon}} **{{check.result}}** {{check.description}} <a href="https://fontbakery.readthedocs.io/en/stable/fontbakery/checks/{{check.module}}.html#{{check.id | replace("_", "-") | replace("/", "-") | replace(".", "-")}}">{{check.id}}</a></summary>
     <div>
 
-{% if not succinct %}
+{% if not succinct and check.rationale %}
 {% for line in check.rationale.split("\n") %}> {{line | unwrap | replace("\n", "") }}
 {% endfor %}
 {% endif %}

--- a/Lib/fontbakery/reporters/templates/markdown/check.markdown
+++ b/Lib/fontbakery/reporters/templates/markdown/check.markdown
@@ -7,6 +7,12 @@
 {% endfor %}
 {% endif %}
 
+{% if check.proposal and not succinct %}
+{% for proposal in check.proposal %}{% if loop.index == 1 %}> Original proposal: {{proposal}}
+{% else %}> See also: {{proposal}}
+{%endif%}{% endfor %}
+{% endif %}
+
 {% for result in check.logs |sort(attribute="status") %}
 {% if not result is omitted %}
 * {{result.status | emoticon }} **{{result.status}}** {{result.message.message}} {%if result.message.code%}[code: {{result.message.code}}]{%endif%}

--- a/Lib/fontbakery/result.py
+++ b/Lib/fontbakery/result.py
@@ -75,12 +75,17 @@ class CheckResult:
         """Return the result as a dictionary with data suitable for serialization."""
         check = self.identity.check
         module = check.__module__.replace("fontbakery.checks.", "")
+        if not isinstance(check.proposal, list):
+            proposal = [check.proposal]
+        else:
+            proposal = check.proposal
         json = {
             "key": self.identity.key,
             "description": check.description,
             "documentation": check.documentation,
             "rationale": check.rationale,
             "experimental": check.experimental,
+            "proposal": proposal,
             "severity": check.severity,
             "result": self.summary_status.name,
             "module": module,


### PR DESCRIPTION
## Description
Relates to issue  #4560,  #4540. Improves both the HTML and Markdown reporters by adding proposal information, and only formatting rationale when there is one.

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

