### PR TITLE
Disable legacy accents check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a2 (2024-Feb-21)
 
 ### Changes to existing checks
+#### On the Universal profile
+  - **DISABLED - [com.google.fonts/check/legacy_accents]:** This is one of the checks that we probably should run on the sources instead of binaries. (https://github.com/fonttools/fontbakery/issues/3959#issuecomment-1822913547)
+
 #### On the Open Type Profile
   - **[com.google.fonts/check/layout_valid_feature_tags]:** Updated the check to allow valid private-use feature tags. (issue #4544)
   - **[com.google.fonts/check/varfont/family_axis_ranges]:** Updated the check to skip fonts without fvar tables. (issue #4554)

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -741,6 +741,7 @@ def com_google_fonts_check_whitespace_ink(ttFont):
         yield PASS, "There is no whitespace glyph with ink."
 
 
+@disable  # https://github.com/fonttools/fontbakery/issues/3959#issuecomment-1822913547
 @check(
     id="com.google.fonts/check/legacy_accents",
     proposal=[

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -16,7 +16,7 @@ PROFILE = {
             "com.google.fonts/check/whitespace_glyphs",
             "com.google.fonts/check/whitespace_glyphnames",
             "com.google.fonts/check/whitespace_ink",
-            "com.google.fonts/check/legacy_accents",
+            # "com.google.fonts/check/legacy_accents",  # Disabled: issue #3595 / PR #4567
             "com.google.fonts/check/required_tables",
             "com.google.fonts/check/unwanted_tables",
             "com.google.fonts/check/valid_glyphnames",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -5072,36 +5072,6 @@ def test_check_alt_caron():
     assert_PASS(check(ttFont))
 
 
-def test_check_legacy_accents():
-    """Check that legacy accents aren't used in composite glyphs."""
-    check = CheckTester("com.google.fonts/check/legacy_accents")
-
-    test_font = TTFont(TEST_FILE("montserrat/Montserrat-Regular.ttf"))
-    assert_PASS(check(test_font))
-
-    test_font = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-    assert_results_contain(
-        check(test_font),
-        FAIL,
-        "legacy-accents-gdef",
-        "for legacy accents being defined in GDEF as marks.",
-    )
-
-    test_font = TTFont(TEST_FILE("lugrasimo/Lugrasimo-Regular.ttf"))
-    assert_results_contain(
-        check(test_font),
-        WARN,
-        "legacy-accents-component",
-        "for legacy accents being used in composites.",
-    )
-    assert_results_contain(
-        check(test_font),
-        FAIL,
-        "legacy-accents-width",
-        "for legacy accents having zero width.",
-    )
-
-
 def test_check_shape_languages():
     """Shapes languages in all GF glyphsets."""
     check = CheckTester("com.google.fonts/check/glyphsets/shape_languages")

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -595,7 +595,7 @@ def test_check_whitespace_ink():
     )
 
 
-def test_check_legacy_accents():
+def DISABLED_test_check_legacy_accents():
     """Check that legacy accents aren't used in composite glyphs."""
     check = CheckTester("com.google.fonts/check/legacy_accents")
 


### PR DESCRIPTION
This is one of the checks that we probably should run on the sources instead of binaries.

**com.google.fonts/check/legacy_accents**
On the Universal profile.

(https://github.com/fonttools/fontbakery/issues/3959#issuecomment-1822913547)