### PR TITLE
gf conditions: get tagging data from 2nd sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - And also includes the changes from the previous release-candidates:
     - v0.12.0a1 (2024-Feb-14)
     - v0.12.0a2 (2024-Feb-21)
+  - In the googlefonts profile, get family tagging data from another Google Sheet
 
 ### Changes to existing checks
 #### On the Universal profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 
-## Upcoming release: 0.12.0 (2024-Feb-??)
+## Upcoming release: 0.12.0 (2024-Mar-??)
   - Documentation for profile and check writers has been rewritten.
   - And also includes the changes from the previous release-candidates:
     - v0.12.0a1 (2024-Feb-14)
     - v0.12.0a2 (2024-Feb-21)
-  - In the googlefonts profile, get family tagging data from another Google Sheet
 
 ### Changes to existing checks
+#### On the Google Fonts profile
+  - **[com.google.fonts/check/metadata/has_tags]:** Also fetch family tagging data from a second Google Sheet (Submissions from designers via form: https://forms.gle/jcp3nDv63LaV1rxH6) (PR #4576)
+
 #### On the Universal profile
   - **DISABLED - [com.google.fonts/check/legacy_accents]:** This is one of the checks that we probably should run on the sources instead of binaries. (https://github.com/fonttools/fontbakery/issues/3959#issuecomment-1822913547)
 

--- a/Lib/fontbakery/checks/googlefonts/conditions.py
+++ b/Lib/fontbakery/checks/googlefonts/conditions.py
@@ -21,6 +21,13 @@ GF_TAGS_SHEET_URL = (
     "pub?gid=1193923458&single=true&output=csv"
 )
 
+# Submissions from designers via form https://forms.gle/jcp3nDv63LaV1rxH6
+GF_TAGS_SHEET_URL2 = (
+    "https://docs.google.com/spreadsheets/d/e/"
+    "2PACX-1vQVM--FKzKTWL-8w0l5AE1e087uU_OaQNHR3_kkxxymoZV5XUnHzv9TJIdy7vcd0Saf4m8CMTMFqGcg/"
+    "pub?gid=378442772&single=true&output=csv"
+)
+
 # @condition
 # def glyphsFile(glyphs_file):
 #     import glyphsLib
@@ -508,15 +515,22 @@ def get_glyphsets_fulfilled(ttFont):
     return res
 
 
-_tags_cache = None
+_tags_cache = []
 
 
 def gf_tags():
     import requests
 
-    global _tags_cache  # pylint:disable=W0603
-    if _tags_cache is not None:
+    global _tags_cache  # pylint:disable=W0603,W0602
+    if _tags_cache:
         return _tags_cache
-    req = requests.get(GF_TAGS_SHEET_URL, timeout=10)
-    _tags_cache = list(csv.reader(StringIO(req.text)))
+
+    for url in (GF_TAGS_SHEET_URL, GF_TAGS_SHEET_URL2):
+        req = requests.get(url, timeout=10)
+        data = list(csv.reader(StringIO(req.text)))
+        # drop the first two columns on sheet2 since they contain
+        # the author and form submission date
+        if url == GF_TAGS_SHEET_URL2:
+            data = [i[2:] for i in data]
+        _tags_cache.extend(data)
     return _tags_cache

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -1539,6 +1539,8 @@ def com_google_fonts_check_metadata_empty_designer(family_metadata):
     conditions=["network"],
     rationale="""
         Any font published on Google Fonts must be listed in the tags spreadsheet.
+
+        https://forms.gle/jcp3nDv63LaV1rxH6
     """,
     proposal="https://github.com/fonttools/fontbakery/issues/4465",
 )


### PR DESCRIPTION
## Description

Each family in the Google Fonts collection must have tagging data. We now have a form users can fill in to provide tags for their families, https://docs.google.com/forms/d/e/1FAIpQLScvQKapFIPcLezWbam1Os7OWWj90txJgXpvBRx7OQ3uHKzwLw/viewform. This form populates another sheet in the Google Sheet. This PR will fetch the data from the other sheet and combine it with the existing sheet.

Merging this PR will allow the following PRs to pass in google/fonts:

<img width="812" alt="Screenshot 2024-03-04 at 15 45 29" src="https://github.com/fonttools/fontbakery/assets/7525512/44bf172e-402d-40b6-9619-60dcb0c322ad">



## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

