### PR TITLE
Deprecate `check/metadata/valid_name_values`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### Deprecated checks
 #### Removed from the Open Type profile
-  - **[com.google.fonts/check/family/panose_proportion]:** (issue #4083)
-  - **[com.google.fonts/check/family/equal_unicode_encodings]:** (issue #4569)
+  - **DEPRECATED - [com.google.fonts/check/family/equal_unicode_encodings]:** (issue #4569)
+  - **DEPRECATED - [com.google.fonts/check/family/panose_proportion]:** (issue #4083)
+
+#### Removed from the Google Fonts profile
+  - **DEPRECATED - [com.google.fonts/check/metadata/valid_name_values]:** (issue #4571)
 
 ### Changes to existing checks
 #### On the Google Fonts profile

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -771,30 +771,6 @@ def com_google_fonts_check_metadata_match_filename_postscript(font_metadata):
 
 
 @check(
-    id="com.google.fonts/check/metadata/valid_name_values",
-    conditions=["ttFont", "font_metadata"],
-    proposal="legacy:check/098",
-    rationale="""
-        This check ensures that the font.name field in the METADATA.pb file
-        matches the family name of the font.
-    """,
-)
-def com_google_fonts_check_metadata_valid_name_values(ttFont, font_metadata):
-    """METADATA.pb font.name field matches font"""
-    family_name = ttFont["name"].getBestFamilyName()
-    if family_name != font_metadata.name:
-        yield FAIL, Message(
-            "mismatch",
-            (
-                f"METADATA.pb font.name field is {font_metadata.name} "
-                f"but font has {family_name}"
-            ),
-        )
-    else:
-        yield PASS, "METADATA.pb font.name is correct"
-
-
-@check(
     id="com.google.fonts/check/metadata/valid_full_name_values",
     conditions=["style", "font_metadata"],
     proposal="legacy:check/099",

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -29,7 +29,6 @@ PROFILE = {
             "com.google.fonts/check/metadata/match_filename_postscript",
             "com.google.fonts/check/metadata/match_weight_postscript",
             "com.google.fonts/check/metadata/minisite_url",
-            "com.google.fonts/check/metadata/valid_name_values",
             "com.google.fonts/check/metadata/valid_full_name_values",
             "com.google.fonts/check/metadata/valid_filename_values",
             "com.google.fonts/check/metadata/valid_post_script_name_values",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -1855,32 +1855,6 @@ MONTSERRAT_NON_RIBBI = [
 ]
 
 
-def test_check_metadata_valid_name_values():
-    """METADATA.pb font.name field matches font"""
-    check = CheckTester("com.google.fonts/check/metadata/valid_name_values")
-
-    # Our reference Montserrat family is a good 18-styles family:
-    for font in MONTSERRAT_RIBBI + MONTSERRAT_NON_RIBBI:
-        # So it must PASS the check:
-        ttfont = TTFont(font)
-        assert_PASS(check(ttfont), f"with a good RIBBI font ({font})...")
-
-        # And fail if it finds a bad font_familyname:
-        ttfont["name"].setName("foobar", 1, 3, 1, 0x409)
-        ttfont["name"].setName("foobar", 16, 3, 1, 0x409)
-        assert_results_contain(
-            check(ttfont),
-            FAIL,
-            "mismatch",
-            f"with a bad RIBBI font ({font})...",
-        )
-
-    # Good font with other language name entries
-    font = TEST_FILE("bizudpmincho-nameonly/BIZUDPMincho-Regular.ttf")
-
-    assert_PASS(check(font), "with a good font with other languages...")
-
-
 def test_check_metadata_valid_full_name_values():
     """METADATA.pb font.full_name field contains font name in right format?"""
     check = CheckTester("com.google.fonts/check/metadata/valid_full_name_values")


### PR DESCRIPTION
**com.google.fonts/check/metadata/valid_name_values**
Removed from the Google Fonts profile.

**Note:** The check was redundant; The same checking is already performed by **com.google.fonts/check/metadata/nameid/font_name** on the same profile.

(issue #4571)