### PR TITLE
Deprecated a couple METADATA.pb / name table checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ A more detailed list of changes is available in the corresponding milestones for
   - **DEPRECATED - [com.google.fonts/check/family/panose_proportion]:** (issue #4083)
 
 #### Removed from the Google Fonts profile
+  - **DEPRECATED - [com.google.fonts/check/metadata/nameid/family_name]:** (issue #4572)
+  - **DEPRECATED - [com.google.fonts/check/metadata/nameid/full_name]:** (issue #4572)
   - **DEPRECATED - [com.google.fonts/check/metadata/valid_name_values]:** (issue #4571)
 
 ### Changes to existing checks

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -506,53 +506,6 @@ def com_google_fonts_check_metadata_regular_is_400(family_metadata):
 
 
 @check(
-    id="com.google.fonts/check/metadata/nameid/family_name",
-    conditions=["font_metadata"],
-    proposal="legacy:check/092",
-    rationale="""
-        This check ensures that the family name declared in the METADATA.pb file
-        matches the family name declared in the name table of the font file.
-        If the font was uploaded by the packager, this should always be the
-        case. But if there were manual changes to the METADATA.pb file, a mismatch
-        could occur.
-    """,
-)
-def com_google_fonts_check_metadata_nameid_family_name(ttFont, font_metadata):
-    """Checks METADATA.pb font.name field matches
-    family name declared on the name table.
-    """
-    from fontbakery.utils import get_name_entry_strings
-
-    familynames = get_name_entry_strings(ttFont, NameID.TYPOGRAPHIC_FAMILY_NAME)
-    if not familynames:
-        familynames = get_name_entry_strings(ttFont, NameID.FONT_FAMILY_NAME)
-    if len(familynames) == 0:
-        yield FAIL, Message(
-            "missing",
-            (
-                f"This font lacks a FONT_FAMILY_NAME entry"
-                f" (nameID = {NameID.FONT_FAMILY_NAME})"
-                f" in the name table."
-            ),
-        )
-    else:
-        if font_metadata.name not in familynames:
-            yield FAIL, Message(
-                "mismatch",
-                (
-                    f"Unmatched family name in font:"
-                    f' TTF has "{familynames[0]}" while METADATA.pb'
-                    f' has "{font_metadata.name}"'
-                ),
-            )
-        else:
-            yield PASS, (
-                f'Family name "{font_metadata.name}" is identical'
-                f" in METADATA.pb and on the TTF file."
-            )
-
-
-@check(
     id="com.google.fonts/check/metadata/nameid/post_script_name",
     conditions=["font_metadata"],
     proposal="legacy:093",
@@ -601,55 +554,13 @@ def com_google_fonts_check_metadata_nameid_post_script_name(ttFont, font_metadat
         )
 
 
-@check(
-    id="com.google.fonts/check/metadata/nameid/full_name",
-    conditions=["font_metadata"],
-    proposal="legacy:check/094",
-    rationale="""
-        This check ensures that the font full name declared in the METADATA.pb file
-        matches the font full name declared in the name table of the font file.
-        If the font was uploaded by the packager, this should always be the
-        case. But if there were manual changes to the METADATA.pb file, a mismatch
-        could occur.
-    """,
-)
-def com_google_fonts_check_metadata_nameid_full_name(ttFont, font_metadata):
-    """METADATA.pb font.full_name value matches
-    fullname declared on the name table?
-    """
-    from fontbakery.utils import get_name_entry_strings
-
-    full_fontnames = get_name_entry_strings(ttFont, NameID.FULL_FONT_NAME, langID=0x409)
-    # FIXME: only check English names
-    #        https://github.com/fonttools/fontbakery/issues/4000
-
-    if len(full_fontnames) == 0:
-        yield FAIL, Message(
-            "lacks-entry",
-            (
-                f"This font lacks a FULL_FONT_NAME entry"
-                f" (nameID = {NameID.FULL_FONT_NAME})"
-                f" in the name table."
-            ),
-        )
-    else:
-        for full_fontname in full_fontnames:
-            if full_fontname != font_metadata.full_name:
-                yield FAIL, Message(
-                    "mismatch",
-                    (
-                        f"Unmatched fullname in font:"
-                        f' TTF has "{full_fontname}" while METADATA.pb'
-                        f' has "{font_metadata.full_name}".'
-                    ),
-                )
-            else:
-                yield PASS, (
-                    f'Font fullname "{full_fontname}" is identical'
-                    f" in METADATA.pb and on the TTF file."
-                )
-
-
+# FIXME! This looks suspiciously similar to the now deprecated
+#          com.google.fonts/check/metadata/nameid/family_name
+#
+#        Also similar to the current
+#          com.google.fonts/check/metadata/nameid/family_and_full_names
+#
+#        See also: issue #4581
 @check(
     id="com.google.fonts/check/metadata/nameid/font_name",
     rationale="""

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -16,14 +16,16 @@ PROFILE = {
             "com.google.fonts/check/metadata/familyname",
             "com.google.fonts/check/metadata/has_regular",
             "com.google.fonts/check/metadata/regular_is_400",
-            "com.google.fonts/check/metadata/nameid/family_name",
             "com.google.fonts/check/metadata/nameid/post_script_name",
-            "com.google.fonts/check/metadata/nameid/full_name",
-            # FIXME! This seems redundant!
             "com.google.fonts/check/metadata/nameid/family_and_full_names",
             "com.google.fonts/check/metadata/nameid/copyright",
-            # FIXME! This looks suspiciously similar
-            # to com.google.fonts/check/metadata/nameid/family_name
+            # FIXME! The check below (metadata/nameid/font_name) looks
+            #        suspiciously similar to the now deprecated
+            #          com.google.fonts/check/metadata/nameid/family_name
+            #        which is similar to
+            #          com.google.fonts/check/metadata/nameid/family_and_full_names
+            #
+            #        See also: issue #4581
             "com.google.fonts/check/metadata/nameid/font_name",
             "com.google.fonts/check/metadata/match_fullname_postscript",
             "com.google.fonts/check/metadata/match_filename_postscript",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -1627,31 +1627,6 @@ def test_check_metadata_regular_is_400():
     assert "Unfulfilled Conditions: has_regular_style" in msg
 
 
-def test_check_metadata_nameid_family_name():
-    """Checks METADATA.pb font.name field matches
-    family name declared on the name table."""
-    check = CheckTester("com.google.fonts/check/metadata/nameid/family_name")
-
-    # Let's start with the METADATA.pb file from our reference FamilySans family:
-    font = TEST_FILE("familysans/FamilySans-Regular.ttf")
-
-    # We know that Family Sans Regular is good here:
-    assert_PASS(check(font))
-
-    # Then cause it to fail:
-    md = Font(font).font_metadata
-    md.name = "Foo"
-    assert_results_contain(
-        check(MockFont(file=font, font_metadata=md)), FAIL, "mismatch"
-    )
-
-    # TODO: the failure-mode below seems more generic than the scope
-    #       of this individual check. This could become a check by itself!
-    #
-    # code-paths:
-    # - FAIL code="missing", "Font lacks a FONT_FAMILY_NAME entry"
-
-
 def test_check_metadata_nameid_post_script_name():
     """Checks METADATA.pb font.post_script_name matches
     postscript name declared on the name table."""
@@ -1675,49 +1650,6 @@ def test_check_metadata_nameid_post_script_name():
     #
     # code-paths:
     # - FAIL code="missing", "Font lacks a POSTSCRIPT_NAME"
-
-
-def test_check_metadata_nameid_full_name():
-    """METADATA.pb font.fullname value matches fullname declared on the name table ?"""
-    check = CheckTester("com.google.fonts/check/metadata/nameid/full_name")
-
-    font = TEST_FILE("merriweather/Merriweather-Regular.ttf")
-
-    assert_PASS(check(font), "with a good font...")
-
-    # here we change the font.fullname on the METADATA.pb
-    # to introduce a "mismatch" error condition:
-    md = Font(font).font_metadata
-    good = md.full_name
-    md.full_name = good + "bad-suffix"
-
-    assert_results_contain(
-        check(MockFont(file=font, font_metadata=md)),
-        FAIL,
-        "mismatch",
-        "with mismatching fullname values...",
-    )
-
-    # and restore the good value prior to the next test case:
-    md.full_name = good
-
-    # And here we remove all FULL_FONT_NAME entries
-    # in order to get a "lacks-entry" error condition:
-    ttFont = TTFont(font)
-    for i, name in enumerate(ttFont["name"].names):
-        if name.nameID == NameID.FULL_FONT_NAME:
-            del ttFont["name"].names[i]
-    assert_results_contain(
-        check(ttFont),
-        FAIL,
-        "lacks-entry",
-        "when a font lacks FULL_FONT_NAME entries in its name table...",
-    )
-
-    # Good font with other language name entries
-    font = TEST_FILE("bizudpmincho-nameonly/BIZUDPMincho-Regular.ttf")
-
-    assert_PASS(check(font), "with a good font with other languages...")
 
 
 def test_check_metadata_nameid_font_name():
@@ -1781,7 +1713,7 @@ def test_check_metadata_match_fullname_postscript():
     #       There's some relevant info at:
     #       https://github.com/fonttools/fontbakery/issues/1517
     #
-    # FIXME: com.google.fonts/check/metadata/nameid/full_name
+    # FIXME: com.google.fonts/check/metadata/nameid/family_and_full_names
     #        ties the full_name values from the METADATA.pb file and the
     #        internal name table entry (FULL_FONT_NAME)
     #        to be strictly identical. So it seems that the test below is


### PR DESCRIPTION
**com.google.fonts/check/metadata/nameid/family_name**
**com.google.fonts/check/metadata/nameid/full_name**
Removed from the Google Fonts profile.

These were redundant with
**com.google.fonts/check/metadata/nameid/family_and_full_names**

(issue #4572)