### PR TITLE
Deprecated METADATA.pb multiple_designers check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **DEPRECATED - [com.google.fonts/check/family/panose_proportion]:** (issue #4083)
 
 #### Removed from the Google Fonts profile
+  - **DEPRECATED - [com.google.fonts/check/metadata/multiple_designers]:** (issue #4574)
   - **DEPRECATED - [com.google.fonts/check/metadata/nameid/family_name]:** (issue #4572)
   - **DEPRECATED - [com.google.fonts/check/metadata/nameid/full_name]:** (issue #4572)
   - **DEPRECATED - [com.google.fonts/check/metadata/valid_name_values]:** (issue #4571)

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -63,32 +63,6 @@ def com_google_fonts_check_metadata_unknown_designer(family_metadata):
 
 
 @check(
-    id="com.google.fonts/check/metadata/multiple_designers",
-    conditions=["family_metadata"],
-    rationale="""
-        For a while the string "Multiple designers" was used as a placeholder on
-        METADATA.pb files. We should replace all those instances with actual designer
-        names so that proper credits are displayed on the Google Fonts family
-        specimen pages.
-
-        If there's more than a single designer, the designer names must be
-        separated by commas.
-    """,
-    proposal="https://github.com/fonttools/fontbakery/issues/2766",
-)
-def com_google_fonts_check_metadata_multiple_designers(family_metadata):
-    """Font designer field in METADATA.pb must not contain 'Multiple designers'."""
-    if "multiple designer" in family_metadata.designer.lower():
-        yield FAIL, Message(
-            "multiple-designers",
-            f"Font designer field is '{family_metadata.designer}'."
-            f" Please add an explicit comma-separated list of designer names.",
-        )
-    else:
-        yield PASS, "Looks good."
-
-
-@check(
     id="com.google.fonts/check/metadata/designer_values",
     conditions=["family_metadata"],
     rationale="""

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -4,7 +4,6 @@ PROFILE = {
         "Metadata Checks": [
             "com.google.fonts/check/metadata/parses",
             "com.google.fonts/check/metadata/unknown_designer",
-            "com.google.fonts/check/metadata/multiple_designers",
             "com.google.fonts/check/metadata/designer_values",
             "com.google.fonts/check/metadata/unique_full_name_values",
             "com.google.fonts/check/metadata/unique_weight_style_pairs",


### PR DESCRIPTION
**com.google.fonts/check/metadata/multiple_designers**
Removed from the Google Fonts profile

It was redundant, because this other check performs the same validation:
**com.google.fonts/check/metadata/designer_profiles**

(issue #4574)