### PR TITLE
Deprecated METADATA.pb unknown_designer check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **DEPRECATED - [com.google.fonts/check/metadata/multiple_designers]:** (issue #4574)
   - **DEPRECATED - [com.google.fonts/check/metadata/nameid/family_name]:** (issue #4572)
   - **DEPRECATED - [com.google.fonts/check/metadata/nameid/full_name]:** (issue #4572)
+  - **DEPRECATED - [com.google.fonts/check/metadata/unknown_designer]:** (issue #4573)
   - **DEPRECATED - [com.google.fonts/check/metadata/valid_name_values]:** (issue #4571)
 
 ### Changes to existing checks

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -42,27 +42,6 @@ def com_google_fonts_check_metadata_parses(family_directory):
 
 
 @check(
-    id="com.google.fonts/check/metadata/unknown_designer",
-    conditions=["family_metadata"],
-    proposal=[
-        "legacy:check/007",
-        "https://github.com/fonttools/fontbakery/issues/800",
-    ],
-    rationale="""
-        The designer field in METADATA.pb must not be 'unknown'.
-    """,
-)
-def com_google_fonts_check_metadata_unknown_designer(family_metadata):
-    """Font designer field in METADATA.pb must not be 'unknown'."""
-    if family_metadata.designer.lower() == "unknown":
-        yield FAIL, Message(
-            "unknown-designer", f"Font designer field is '{family_metadata.designer}'."
-        )
-    else:
-        yield PASS, "Font designer field is not 'unknown'."
-
-
-@check(
     id="com.google.fonts/check/metadata/designer_values",
     conditions=["family_metadata"],
     rationale="""

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -3,7 +3,6 @@ PROFILE = {
     "sections": {
         "Metadata Checks": [
             "com.google.fonts/check/metadata/parses",
-            "com.google.fonts/check/metadata/unknown_designer",
             "com.google.fonts/check/metadata/designer_values",
             "com.google.fonts/check/metadata/unique_full_name_values",
             "com.google.fonts/check/metadata/unique_weight_style_pairs",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -116,7 +116,7 @@ def test_extra_needed_exit_from_conditions(monkeypatch):
     monkeypatch.delitem(sys.modules, module_name, raising=False)
 
     with pytest.raises(SystemExit):
-        check = CheckTester("com.google.fonts/check/metadata/unknown_designer")
+        check = CheckTester("com.google.fonts/check/metadata/designer_profiles")
         font = TEST_FILE("merriweather/Merriweather-Regular.ttf")
         check(font)
 
@@ -619,23 +619,6 @@ def test_check_metadata_parses():
     bad = MockFont(file=TEST_FILE("broken_metadata/foo.ttf"))
     assert_results_contain(
         check(bad), FATAL, "parsing-error", "with a bad METADATA.pb file..."
-    )
-
-
-def test_check_metadata_unknown_designer():
-    """Font designer field in METADATA.pb must not be 'unknown'."""
-    check = CheckTester("com.google.fonts/check/metadata/unknown_designer")
-
-    font = TEST_FILE("merriweather/Merriweather-Regular.ttf")
-    assert_PASS(check(font), "with a good METADATA.pb file...")
-
-    md = Font(font).family_metadata
-    md.designer = "unknown"
-    assert_results_contain(
-        check(MockFont(file=font, family_metadata=md)),
-        FAIL,
-        "unknown-designer",
-        "with a bad METADATA.pb file...",
     )
 
 


### PR DESCRIPTION
**com.google.fonts/check/metadata/unknown_designer**

Removed from the Google Fonts profile

We currently have no fonts with "unknown" designer in any `METADATA.pb` file; and we can't ever have any more, because we also have a check (**com.google.fonts/check/metadata/designer_profiles**) which ensures that a designer in the `METADATA.pb` is listed in the designers catalogue.

(issue #4573)