### PR TITLE
[googlefonts]: override `check/linegaps` to FAIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/family/equal_codepoint_coverage]:** Added rationale. (PR #4570)
   - **[com.google.fonts/check/family/has_license]:** Added rationale. (PR #4570)
   - **[com.google.fonts/check/has_ttfautohint_params]:** Added rationale. (PR #4570)
+  - **[com.google.fonts/check/linegaps]:** Override WARN messages to FAIL-level. (issue #4136)
   - **[com.google.fonts/check/metadata/broken_links]:** Added rationale. (PR #4570)
   - **[com.google.fonts/check/metadata/canonical_weight_value]:** Added rationale. (PR #4570)
   - **[com.google.fonts/check/metadata/canonical_style_names]:** Added rationale. (PR #4570)

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -169,6 +169,18 @@ PROFILE = {
         }
     },
     "overrides": {
+        "com.google.fonts/check/linegaps": [
+            {
+                "code": "hhea",
+                "status": "FAIL",
+                "reason": "For Google Fonts, all messages from this check are considered FAILs.",
+            },
+            {
+                "code": "OS/2",
+                "status": "FAIL",
+                "reason": "For Google Fonts, all messages from this check are considered FAILs.",
+            },
+        ],
         "com.google.fonts/check/italic_angle": [
             {
                 "code": "positive",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -4959,3 +4959,33 @@ def test_check_metadata_minisite_url():
         "trailing-clutter",
         "with a minisite_url with unnecessary trailing /index.html",
     )
+
+
+def test_check_linegaps():
+    """Checking Vertical Metric Linegaps."""
+    check = CheckTester("com.google.fonts/check/linegaps", profile=googlefonts_profile)
+
+    # Our reference Mada Regular is know to be bad here.
+    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+
+    # But just to be sure, we first explicitely set
+    # the values we're checking for:
+    ttFont["hhea"].lineGap = 1
+    ttFont["OS/2"].sTypoLineGap = 0
+    assert_results_contain(check(ttFont), FAIL, "hhea", "with non-zero hhea.lineGap...")
+
+    # Then we run the check with a non-zero OS/2.sTypoLineGap:
+    ttFont["hhea"].lineGap = 0
+    ttFont["OS/2"].sTypoLineGap = 1
+    assert_results_contain(
+        check(ttFont), FAIL, "OS/2", "with non-zero OS/2.sTypoLineGap..."
+    )
+
+    # And finaly we fix it by making both values equal to zero:
+    ttFont["hhea"].lineGap = 0
+    ttFont["OS/2"].sTypoLineGap = 0
+    assert_PASS(check(ttFont))
+
+    # Confirm the check yields FAIL if the font doesn't have a required table
+    del ttFont["OS/2"]
+    assert_results_contain(check(ttFont), FAIL, "lacks-table")


### PR DESCRIPTION
Override WARN messages to FAIL-level.
**com.google.fonts/check/linegaps**
On the Google Fonts profile.

(issue #4136)