### PR TITLE
Remove deprecated check from typenetwork profile

### DIFF
--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -138,7 +138,6 @@ PROFILE = {
             "com.google.fonts/check/name/italic_names",
         ],
         "OS/2 table": [
-            "com.google.fonts/check/family/panose_proportion",
             "com.google.fonts/check/family/panose_familytype",
             "com.google.fonts/check/xavgcharwidth",
             "com.adobe.fonts/check/fsselection_matches_macstyle",


### PR DESCRIPTION
## Description
Relates to issue #4519. We deprecated the panose_proportion check - well, we *removed* it; we should probably have a formal deprecation protocol - but did not remove it from the typenetwork profile.

This is a quick fix, I'll follow up with a PR which makes sure that all of our profiles go through the install_run check.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

