### PR TITLE
Handle vendor IDs that are fewer than 4 characters

### DIFF
--- a/Lib/fontbakery/checks/opentype/os2.py
+++ b/Lib/fontbakery/checks/opentype/os2.py
@@ -356,7 +356,7 @@ def com_thetypefounders_check_vendor_id(config, ttFont):
         return
 
     config_vendor_id = config["vendor_id"]
-    font_vendor_id = ttFont["OS/2"].achVendID
+    font_vendor_id = ttFont["OS/2"].achVendID.replace(" ","").replace("\x00","")
 
     if config_vendor_id != font_vendor_id:
         yield FAIL, Message(


### PR DESCRIPTION
## Description

The OS/2 Vendor ID is specced as a string of four characters. However, a font Vendor ID will often be fewer than four characters, so this field gets filled in with either spaces or null characters. For example, here’s how vendor `ABC` might appear:

```xml
<achVendID value="ABC\x00"/>
```

```xml
<achVendID value="ABC "/>
```

So, this PR strips those filled characters out before comparing the vendor ID against the configured expectation.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

