### PR TITLE
[googlefonts] new check: article/images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a4 (2024-Mar-15)
   - Implement a basic tool to update regression test files. See https://github.com/fonttools/fontbakery/discussions/4589 for details. Run like `python -m fontbakery.update_shaping_tests input.toml output.json path/to/*.ttf`.
 
+### New checks
+#### Added to the Google Fonts profile
+  - **EXPERIMENTAL - [com.google.fonts/check/article/images]:** Validate maximum filesize and resolution of images in the article/images directory. (issue #4594)
+
 
 ## 0.12.0a4 (2024-Mar-15)
   - Fixed markdown/html reporters (issue #4595)

--- a/Lib/fontbakery/checks/googlefonts/article.py
+++ b/Lib/fontbakery/checks/googlefonts/article.py
@@ -1,0 +1,106 @@
+import os
+
+from fontbakery.prelude import check, Message, PASS, FAIL, WARN
+
+
+@check(
+    id="com.google.fonts/check/article/images",
+    conditions=["family_directory"],
+    rationale="""
+        The purpose of this check is to ensure images (either raster or vector files)
+        are placed on the correct directory (an `images` subdirectory inside `article`) and
+        they they are not excessively large in filesize and resolution.
+    """,
+    proposal="https://github.com/fonttools/fontbakery/issues/4594",
+    experimental="Since 2024/Mar/19",
+)
+def com_google_fonts_check_metadata_parses(config, family_directory):
+    """Validate location, size and resolution of article images."""
+
+    from fontbakery.utils import bullet_list, image_dimensions
+
+    MAX_WIDTH = 2048
+    MAX_HEIGHT = 1024
+    MAXSIZE_VECTOR = 1750 * 1024  # 1750kb
+    MAXSIZE_RASTER = 800 * 1024  # 800kb
+
+    def is_raster(filename):
+        for ext in ["png", "jpg", "gif"]:
+            if filename.lower().endswith(f".{ext}"):
+                return True
+        return False
+
+    def is_vector(filename):
+        for ext in ["svg"]:
+            if filename.lower().endswith(f".{ext}"):
+                return True
+        return False
+
+    passed = True
+    article_dir = os.path.join(family_directory, "article")
+    images_dir = os.path.join(family_directory, "article", "images")
+    if not os.path.isdir(article_dir):
+        passed = False
+        yield WARN, Message(
+            "lacks-article",
+            f"Family metadata at {family_directory} does not have an article.\n",
+        )
+    else:
+        misplaced_files = [
+            os.path.join(article_dir, filename)
+            for filename in os.listdir(article_dir)
+            if is_vector(filename) or is_raster(filename)
+        ]
+        all_image_files = misplaced_files
+        if os.path.isdir(images_dir):
+            all_image_files += [
+                os.path.join(images_dir, filename)
+                for filename in os.listdir(images_dir)
+                if is_vector(filename) or is_raster(filename)
+            ]
+        if misplaced_files:
+            passed = False
+            yield FAIL, Message(
+                "misplaced-image-files",
+                f"There are {len(misplaced_files)} image files in the `article` directory"
+                f" and they should be moved to an `article/images` subdirectory.\n\n"
+                f" Misplaced files:\n\n"
+                f"{bullet_list(config, misplaced_files)}\n",
+            )
+
+        for filename in all_image_files:
+            if is_vector(filename):
+                maxsize = MAXSIZE_VECTOR
+                imagetype = "vector"
+            elif is_raster(filename):
+                maxsize = MAXSIZE_RASTER
+                imagetype = "raster"
+            else:
+                # ignore this file type
+                continue
+
+            filesize = os.stat(filename).st_size
+            if filesize > maxsize:
+                passed = False
+                yield FAIL, Message(
+                    "filesize",
+                    f"`{filename}` has `{filesize} bytes`, but the maximum filesize"
+                    f" for {imagetype} images is `{maxsize} bytes`.",
+                )
+
+            dim = image_dimensions(filename)
+            if dim is None:
+                # Could not detect image dimensions
+                continue
+
+            w, h = dim
+            if w > MAX_WIDTH or h > MAX_HEIGHT:
+                passed = False
+                yield FAIL, Message(
+                    "image-too-large",
+                    f"Image is too large: `{w} x {h} pixels`\n\n"
+                    f"Max resulution allowed: `{MAX_WIDTH} x {MAX_HEIGHT} pixels`",
+                )
+
+    if passed:
+        yield PASS, "All looks good!"

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -1,6 +1,9 @@
 PROFILE = {
     "include_profiles": ["universal", "outline", "shaping", "ufo"],
     "sections": {
+        "Article Checks": [
+            "com.google.fonts/check/article/images",
+        ],
         "Metadata Checks": [
             "com.google.fonts/check/metadata/broken_links",
             "com.google.fonts/check/metadata/canonical_style_names",

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -669,3 +669,36 @@ def show_inconsistencies(dictionary, config):
             for value, files in dictionary.items()
         ],
     )
+
+
+def image_dimensions(filename):
+    if filename.lower().endswith(".png"):
+        data = open(filename, "rb").read(24)
+        if data[0:4] != b"\x89PNG" and data[12:16] != b"IHDR":
+            return None  # Does not look like a PNG!
+
+        w = data[16]
+        w = w << 8 | data[17]
+        w = w << 8 | data[18]
+        w = w << 8 | data[19]
+
+        h = data[20]
+        h = h << 8 | data[21]
+        h = h << 8 | data[22]
+        h = h << 8 | data[23]
+        return w, h
+
+    elif filename.lower().endswith(".gif"):
+        data = open(filename, "rb").read(10)
+        if data[0:4] != b"GIF8":
+            return None  # Does not look like a GIF!
+
+        w = data[7]
+        w = w << 8 | data[6]
+
+        h = data[9]
+        h = h << 8 | data[8]
+        return w + 1, h + 1
+
+    else:
+        return None  # some other file format

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -4989,3 +4989,22 @@ def test_check_linegaps():
     # Confirm the check yields FAIL if the font doesn't have a required table
     del ttFont["OS/2"]
     assert_results_contain(check(ttFont), FAIL, "lacks-table")
+
+
+def test_check_article_images():
+    """Validate location, size and resolution of article images."""
+    check = CheckTester("com.google.fonts/check/article/images")
+
+    # This one is know to be bad:
+    family_dir = TEST_FILE("tirodevanagarihindi")
+
+    assert_results_contain(
+        check(MockFont(family_directory=family_dir)),
+        FAIL,
+        "misplaced-image-files",
+        "The files are not in the correct directory...",
+    )
+
+    # TODO: test WARN "lacks-article"
+    # TODO: test FAIL "image-too-large"
+    # TODO: test PASS


### PR DESCRIPTION
The purpose of this check is to ensure images (either raster or vector files) are placed on the correct directory (an `images` subdirectory inside `article`) and they they are not excessively large in filesize and resolution.

**EXPERIMENTAL - com.google.fonts/check/article/images**
Added to the `Google Fonts` profile.

(issue #4594)