### PR TITLE
Report each code once in succinct mode

### DIFF
--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -305,10 +305,10 @@ class TerminalReporter(FontbakeryReporter):
             )
         else:
             codes = ", ".join(
-                [
+                set(
                     f"[message-{m.status.name}]{m.message.code}[/]"
                     for m in checkresult.results
-                ]
+                )
             )
             self._console.print(
                 f"[message-{msg.name}]{msg.name}[/message-{msg.name}] \\[{codes}]"


### PR DESCRIPTION
## Description

Rather than

```
BriemHand[wght].ttf: com.google.fonts/check/tabular_kerning: FAIL [has-tabular-kerning, has-tabular-kerning, has-tabular-kerning,
has-tabular-kerning, has-tabular-kerning, has-tabular-kerning,
has-tabular-kerning, has-tabular-kerning, has-tabular-kerning,
has-tabular-kerning, has-tabular-kerning, has-tabular-kerning,
has-tabular-kerning, has-tabular-kerning, has-tabular-kerning,
has-tabular-kerning, has-tabular-kerning, has-tabular-kerning,
...
```

it makes more sense to say:

```
BriemHand[wght].ttf: com.google.fonts/check/tabular_kerning: FAIL [has-tabular-kerning]
```

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

