### PR TITLE
mock HTTP requests in the test suite

### DIFF
--- a/Lib/fontbakery/checks/googlefonts/description.py
+++ b/Lib/fontbakery/checks/googlefonts/description.py
@@ -32,7 +32,7 @@ def description_html(font):
         return None
 
 
-def github_gfonts_description(font: Font, network):
+def github_gfonts_description(font: Font, network, config):
     """Get the contents of the DESCRIPTION.en_us.html file
     from the google/fonts github repository corresponding
     to a given ttFont.
@@ -41,8 +41,7 @@ def github_gfonts_description(font: Font, network):
     if not license_file or not network:
         return None
 
-    from fontbakery.utils import download_file
-    from urllib.request import HTTPError
+    import requests
 
     LICENSE_DIRECTORY = {"OFL.txt": "ofl", "UFL.txt": "ufl", "LICENSE.txt": "apache"}
     filename = os.path.basename(font.file)
@@ -52,10 +51,8 @@ def github_gfonts_description(font: Font, network):
         f"/{LICENSE_DIRECTORY[license_file]}/{familyname}/DESCRIPTION.en_us.html"
     )
     try:
-        descfile = download_file(url)
-        if descfile:
-            return descfile.read().decode("UTF-8")
-    except HTTPError:
+        return requests.get(url, timeout=config.get("timeout")).text
+    except requests.RequestException:
         return None
 
 
@@ -411,11 +408,11 @@ def com_google_fonts_check_description_eof_linebreak(description):
     conditions=["description", "network"],
     proposal="https://github.com/fonttools/fontbakery/issues/3182",
 )
-def com_google_fonts_check_description_family_update(font, network):
+def com_google_fonts_check_description_family_update(font, network, config):
     """
     On a family update, the DESCRIPTION.en_us.html file should ideally also be updated.
     """
-    remote_description = github_gfonts_description(font, network)
+    remote_description = github_gfonts_description(font, network, config)
     if remote_description == font.description:
         yield WARN, Message(
             "description-not-updated",

--- a/Lib/fontbakery/checks/googlefonts/vmetrics.py
+++ b/Lib/fontbakery/checks/googlefonts/vmetrics.py
@@ -15,7 +15,7 @@ def typo_metrics_enabled(ttFont):
 
 @check(
     id="com.google.fonts/check/vertical_metrics",
-    conditions=["not remote_styles", "not is_cjk_font"],
+    conditions=["not listed_on_gfonts_api", "not is_cjk_font"],
     rationale="""
         This check generally enforces Google Fonts’ vertical metrics specifications.
         In particular:
@@ -291,7 +291,7 @@ def com_google_fonts_check_vertical_metrics_regressions(regular_ttFont, font):
 
 @check(
     id="com.google.fonts/check/cjk_vertical_metrics",
-    conditions=["is_cjk_font", "not remote_styles"],
+    conditions=["is_cjk_font", "not listed_on_gfonts_api"],
     rationale="""
         CJK fonts have different vertical metrics when compared to Latin fonts.
         We follow the schema developed by dr Ken Lunde for Source Han Sans and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ tests = [
     "pylint == 3.0.3",
 	"pytest-cov == 4.1.0",
 	"pytest-xdist == 3.5.0",
+	"requests-mock == 1.10.0",
 
 	"fontbakery[all]",
 ]

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -3483,12 +3483,12 @@ def test_check_vertical_metrics():
     font = TEST_FILE("akshar/Akshar[wght].ttf")
 
     msg = assert_results_contain(check(font), SKIP, "unfulfilled-conditions")
-    assert "Unfulfilled Conditions: not remote_styles" in msg
+    assert "Unfulfilled Conditions: not listed_on_gfonts_api" in msg
 
-    # Defeat the 'not remote_styles' condition.
+    # Defeat the 'not listed_on_gfonts_api' condition.
     # linegap is not 0
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False)),
+        check(MockFont(file=font, listed_on_gfonts_api=False)),
         FAIL,
         "bad-hhea.lineGap",
         'hhea.lineGap is "150" it should be 0',
@@ -3501,7 +3501,7 @@ def test_check_vertical_metrics():
     ttFont["hhea"].descent = -2000
     ttFont["OS/2"].sTypoDescender = -2000
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "bad-hhea-range",
         "hhea sum is above 2000",
@@ -3511,7 +3511,7 @@ def test_check_vertical_metrics():
     ttFont["hhea"].descent = 0
     ttFont["OS/2"].sTypoDescender = 0
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "bad-hhea-range",
         "hhea sum is below 1200",
@@ -3521,7 +3521,7 @@ def test_check_vertical_metrics():
     ttFont["hhea"].descent = -700
     ttFont["OS/2"].sTypoDescender = -700
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         WARN,
         "bad-hhea-range",
         "hhea sum is above 1500",
@@ -3530,7 +3530,7 @@ def test_check_vertical_metrics():
     # hhea sum is in range
     ttFont["hhea"].descent = -300
     ttFont["OS/2"].sTypoDescender = -300
-    assert_PASS(check(MockFont(file=font, remote_styles=False, ttFont=ttFont)))
+    assert_PASS(check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)))
 
     # reset
     def reset_metrics():
@@ -3547,7 +3547,7 @@ def test_check_vertical_metrics():
     reset_metrics()
     ttFont["OS/2"].sTypoAscender = -900
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "typo-ascender",
         "typo ascender is negative",
@@ -3555,7 +3555,7 @@ def test_check_vertical_metrics():
     reset_metrics()
     ttFont["hhea"].ascent = -900
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "hhea-ascent",
         "hhea ascent is negative",
@@ -3565,7 +3565,7 @@ def test_check_vertical_metrics():
     reset_metrics()
     ttFont["OS/2"].sTypoDescender = 300
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "typo-descender",
         "typo descender is positive",
@@ -3573,7 +3573,7 @@ def test_check_vertical_metrics():
     reset_metrics()
     ttFont["hhea"].descent = 300
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "hhea-descent",
         "hhea descent is positive",
@@ -3583,7 +3583,7 @@ def test_check_vertical_metrics():
     reset_metrics()
     ttFont["OS/2"].usWinAscent = -900
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "win-ascent",
         "OS/2.usWinAscent is negative",
@@ -3593,7 +3593,7 @@ def test_check_vertical_metrics():
     reset_metrics()
     ttFont["OS/2"].usWinDescent = -300
     assert_results_contain(
-        check(MockFont(file=font, remote_styles=False, ttFont=ttFont)),
+        check(MockFont(file=font, listed_on_gfonts_api=False, ttFont=ttFont)),
         FAIL,
         "win-descent",
         "OS/2.usWinDescent is negative",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -4,10 +4,15 @@ import shutil
 import sys
 
 import pytest
+import requests
 from conftest import ImportRaiser, remove_import_raiser
 from fontTools.ttLib import TTFont
 
-from fontbakery.checks.googlefonts.conditions import expected_font_names
+from fontbakery.checks.googlefonts.conditions import (
+    expected_font_names,
+    GF_TAGS_SHEET_URL,
+    GF_TAGS_SHEET_URL2,
+)
 from fontbakery.checks.googlefonts.glyphset import can_shape
 from fontbakery.codetesting import (
     GLYPHSAPP_TEST_FILE,
@@ -183,9 +188,14 @@ def test_check_canonical_filename(fp, result):
         )
 
 
-def test_check_description_broken_links():
+def test_check_description_broken_links(requests_mock):
     """Does DESCRIPTION file contain broken links ?"""
     check = CheckTester("com.google.fonts/check/description/broken_links")
+
+    requests_mock.head("http://example.com/", text="good")
+    requests_mock.head("http://fonts.google.com/", text="good")
+    requests_mock.head("http://thisisanexampleofabrokenurl.com/", status_code=404)
+    requests_mock.head("http://timeout.example.invalid/", exc=requests.Timeout())
 
     font = TEST_FILE("cabin/Cabin-Regular.ttf")
     assert_PASS(check(font), "with description file that has no links...")
@@ -222,7 +232,16 @@ def test_check_description_broken_links():
         "with a description file containing a known-bad URL...",
     )
 
-    # TODO: WARN, 'timeout'
+    bad_desc = (
+        good_desc
+        + "<a href='http://timeout.example.invalid/'>This is a link that times out</a>"
+    )
+    assert_results_contain(
+        check(MockFont(file=font, description=bad_desc)),
+        WARN,
+        "timeout",
+        "with a description file containing a URL that times out...",
+    )
 
 
 def test_check_description_git_url():
@@ -1469,17 +1488,25 @@ def test_check_metadata_subsets_order():
         )
 
 
-def test_check_metadata_includes_production_subsets():
+def test_check_metadata_includes_production_subsets(requests_mock):
     """Check METADATA.pb has production subsets."""
     check = CheckTester(
         "com.google.fonts/check/metadata/includes_production_subsets",
     )
 
-    # We need to use a family that is already in production
-    # Our reference Cabin is known to be good
-    fonts = cabin_fonts
+    requests_mock.get(
+        "http://fonts.google.com/metadata/fonts",
+        json={
+            "familyMetadataList": [
+                {
+                    "family": "Cabin",
+                    "subsets": ["menu", "latin", "latin-ext", "vietnamese"],
+                },
+            ],
+        },
+    )
 
-    # So it must PASS the check:
+    fonts = cabin_fonts
     assert_PASS(check(fonts), "with a good METADATA.pb for this family...")
 
     # Then we induce the problem by removing a subset:
@@ -3477,8 +3504,17 @@ def test_check_repo_zip_files(tmp_path):
         os.remove(filepath)
 
 
-def test_check_vertical_metrics():
+def test_check_vertical_metrics(requests_mock):
     check = CheckTester("com.google.fonts/check/vertical_metrics")
+
+    requests_mock.get(
+        "http://fonts.google.com/metadata/fonts",
+        json={
+            "familyMetadataList": [
+                {"family": "Akshar"},
+            ],
+        },
+    )
 
     font = TEST_FILE("akshar/Akshar[wght].ttf")
 
@@ -3743,8 +3779,15 @@ def test_check_vertical_metrics_regressions():
     )
 
 
-def test_check_cjk_vertical_metrics():
+def test_check_cjk_vertical_metrics(requests_mock):
     check = CheckTester("com.google.fonts/check/cjk_vertical_metrics")
+
+    requests_mock.get(
+        "http://fonts.google.com/metadata/fonts",
+        json={
+            "familyMetadataList": [],
+        },
+    )
 
     ttFont = TTFont(cjk_font)
     assert_PASS(check(ttFont), "for Source Han Sans")
@@ -4189,14 +4232,35 @@ def test_check_metadata_escaped_strings():
     assert_results_contain(check(bad), FAIL, "escaped-strings")
 
 
-def test_check_metadata_designer_profiles():
+def test_check_metadata_designer_profiles(requests_mock):
     """METADATA.pb: Designer is listed with the correct name on
     the Google Fonts catalog of designers?"""
     check = CheckTester("com.google.fonts/check/metadata/designer_profiles")
 
+    requests_mock.get(
+        "https://raw.githubusercontent.com/google/fonts/master/"
+        "catalog/designers/delvewithrington/info.pb",
+        status_code=404,
+    )
+    sorkintype_info = """
+        designer: "Sorkin Type"
+        link: ""
+        avatar {
+          file_name: "sorkin_type.png"
+        }
+        """
+    requests_mock.get(
+        "https://raw.githubusercontent.com/google/fonts/master/"
+        "catalog/designers/sorkintype/info.pb",
+        text=sorkintype_info,
+    )
+    requests_mock.get(
+        "https://raw.githubusercontent.com/google/fonts/master/"
+        "catalog/designers/sorkintype/sorkin_type.png",
+        content=b"\x89PNG\x0D\x0A\x1A\x0A",
+    )
+
     # Delve Withrington is still not listed on the designers catalog.
-    # Note: Once it is listed, this code-test will start failing
-    # and will need to be updated.
     font = TEST_FILE("overpassmono/OverpassMono-Regular.ttf")
     assert_results_contain(check(font), WARN, "profile-not-found")
 
@@ -4226,7 +4290,7 @@ def test_check_mandatory_avar_table():
     assert_results_contain(check(ttFont), WARN, "missing-avar")
 
 
-def test_check_description_family_update():
+def test_check_description_family_update(requests_mock):
     """
     On a family update, the DESCRIPTION.en_us.html file should ideally also be updated.
     """
@@ -4234,12 +4298,12 @@ def test_check_description_family_update():
 
     font = TEST_FILE("abeezee/ABeeZee-Regular.ttf")
     ABEEZEE_DESC = (
-        "https://raw.githubusercontent.com/google/fonts/"
-        "main/ofl/abeezee/DESCRIPTION.en_us.html"
+        "https://github.com/google/fonts/raw/main/ofl/abeezee/DESCRIPTION.en_us.html"
     )
-    import requests
 
-    desc = requests.get(ABEEZEE_DESC, timeout=10).text
+    desc = "<html>My fake description.</html>"
+    requests_mock.get(ABEEZEE_DESC, text=desc)
+
     assert_results_contain(
         check(MockFont(file=font, description=desc)), WARN, "description-not-updated"
     )
@@ -4925,9 +4989,21 @@ def test_check_varfont_bold_wght_coord():
     assert_results_contain(check(ttFont), SKIP, "no-bold-weight")
 
 
-def test_check_metadata_has_tags():
+def test_check_metadata_has_tags(requests_mock):
     """The font has tags in the GF Tags spreadsheet"""
     check = CheckTester("com.google.fonts/check/metadata/has_tags")
+
+    fake_gf_tags_sheet = (
+        "Family,Family Dir,Existing Category\n"
+        ",,\n,,\n,,\n,,\n,,\n"
+        "Merriweather,merriweather,SERIF\n"
+    )
+    requests_mock.get(GF_TAGS_SHEET_URL, text=fake_gf_tags_sheet)
+    fake_gf_tags_sheet2 = (
+        "Timestamp,Email Address,Family Name (name ID 1/16),,Category\n"
+        ",,\n,,\n,,\n,,\n,,\n"
+    )
+    requests_mock.get(GF_TAGS_SHEET_URL2, text=fake_gf_tags_sheet2)
 
     font = "data/test/merriweather/Merriweather-Regular.ttf"
     assert_PASS(check(font), "with a name that's in the spreadsheet...")


### PR DESCRIPTION
## Description

I'm working on packaging fontbakery in nixpkgs, which requires that the test suite run without network access. I found a few tests which intentionally make network calls, but in most of them it seems desirable to mock out requests to live services. This will make them faster and more reproducible, and lets them run in an environment like nixpkgs where they are sandboxed from the network.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

