### PR TITLE
Fix instances_in_order for single-axis fonts

### DIFF
--- a/Lib/fontbakery/checks/googlefonts/varfont.py
+++ b/Lib/fontbakery/checks/googlefonts/varfont.py
@@ -653,7 +653,7 @@ def com_google_fonts_check_varfont_instances_in_order(ttFont, config):
     # Partition into sub-lists based on the other axes values.
     # e.g. "Thin Regular", "Bold Regular", "Thin Condensed", "Bold Condensed"
     # becomes [ ["Thin Regular", "Bold Regular"], ["Thin Condensed", "Bold Condensed"] ]
-    sublists = []
+    sublists = [[]]
     last_non_wght = {}
     for coord in coords:
         non_wght = {k: v for k, v in coord.items() if k != "wght"}


### PR DESCRIPTION
## Description

instances_in_order separates the instances based on what *isn't* in the weight axis; if there is only a weight axis, it fails with this error:

```
    ERROR Failed with IndexError: list index out of range


            File
          "/opt/homebrew/lib/python3.11/site-packages/fontbakery/checkrunner.
          ", line 213, in _run_check
              subresults = list(subresults)
                           ^^^^^^^^^^^^^^^^
            File
          "/opt/homebrew/lib/python3.11/site-packages/fontbakery/checks/googl
          onts/varfont.py", line 663, in
          com_google_fonts_check_varfont_instances_in_order
              sublists[-1].append(coord)
              ~~~~~~~~^^^^

          [code: failed-check]
```

This fixes it.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

