### PR TITLE
Remove get_glyphsets_fulfilled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a4 (2024-Mar-15)
     - v0.12.0a5 (2024-Apr-02)
     - v0.12.0a6 (2024-Apr-04)
+    - v0.12.0a7 (2024-Apr-04)
+
+
+## 0.12.0a7 (2024-Apr-04)
+### Release notes
+  - Unpin **glyphsets** dependency.
 
 
 ## 0.12.0a6 (2024-Apr-04)

--- a/Lib/fontbakery/checks/googlefonts/conditions.py
+++ b/Lib/fontbakery/checks/googlefonts/conditions.py
@@ -495,30 +495,6 @@ def expected_font_names(ttFont, ttFonts):
     return font_cp
 
 
-def get_glyphsets_fulfilled(ttFont):
-    """Returns a dictionary of glyphsets that are fulfilled by the font,
-    and the percentage of glyphs in the font that are in the glyphset.
-    This is following the new glyphset definitions in glyphsets.definitions
-    """
-    from glyphsets.definitions import unicodes_per_glyphset, glyphset_definitions
-
-    res = {}
-    unicodes_in_font = set(ttFont.getBestCmap().keys())
-    for glyphset in glyphset_definitions:
-        unicodes_in_glyphset = unicodes_per_glyphset(glyphset)
-        if glyphset not in res:
-            res[glyphset] = {"has": [], "missing": [], "percentage": 0}
-        for unicode in unicodes_in_glyphset:
-            if unicode in unicodes_in_font:
-                res[glyphset]["has"].append(unicode)
-            else:
-                res[glyphset]["missing"].append(unicode)
-        res[glyphset]["percentage"] = len(res[glyphset]["has"]) / len(
-            unicodes_in_glyphset
-        )
-    return res
-
-
 _tags_cache = []
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,7 @@ googlefontsalwayslatest = [
 	"axisregistry >= 0.4.9, == 0.4.*",
 	"gflanguages >= 0.5.17, == 0.5.*",
 	"gfsubsets >= 2024.2.5",
-	"glyphsets == 0.6.14",  #  "glyphsets >= 0.6.14, == 0.6.*",
-    # (see https://github.com/googlefonts/glyphsets/commit/bfd0bb637)
+	"glyphsets >= 0.6.17, == 0.6.*",
 	"shaperglot >= 0.5.0, == 0.5.*",
 ]
 


### PR DESCRIPTION
pytype tests are failing because the glyphsets API changed; we no longer use this condition because we changed the code to use the new API directly, but in my reworking of the conditions, the removal of the old condition got lost.