### PR TITLE
com.google.fonts/check/ttx_roundtrip: use subprocesses to invoke TTX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a5 (2024-Apr-02)
     - v0.12.0a6 (2024-Apr-04)
     - v0.12.0a7 (2024-Apr-04)
+  - Fix multithreading conflict when using `--auto-jobs` and running the [com.google.fonts/check/ttx_roundtrip] check (#4481)
 
 
 ## 0.12.0a7 (2024-Apr-04)

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -1420,7 +1420,7 @@ def com_google_fonts_check_ttx_roundtrip(font):
         if line not in import_error_msgs:
             import_error_msgs.append(line)
 
-    if len(import_error_msgs):
+    if import_error_msgs:
         failed = True
         yield INFO, (
             "While importing an XML file and converting it back to TTF,"


### PR DESCRIPTION
## Description

Should fix #4481 

Refactors `com.google.fonts/check/ttx_roundtrip` to use `subprocess.Popen` on `ttx` instead of calling ttLib directly. This means that we can use `subprocess`' built-in handling of stdout and stderr, instead of the previous `TTXLogger` that was disrupting progress reporting while this check was being run (see [my post](https://github.com/fonttools/fontbakery/issues/4481#issuecomment-2027473182) on #4481 for the full explanation on how these are linked)

I've tested locally and am no longer able to reproduce the original issue

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

