### PR TITLE
Markdown reports: order results by log-level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a5 (2024-Apr-02)
     - v0.12.0a6 (2024-Apr-04)
     - v0.12.0a7 (2024-Apr-04)
+  - Restablish ordering of results on github markdown reports, showing the more severe results (such as FAILs) at the top. (issue #4600)
 
 ### Changes to existing checks
 #### On the Universal profile

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -56,6 +56,13 @@ class GHMarkdownReporter(HTMLReporter):
                             other_checks[key] = []
                         other_checks[key].append(check)
 
+        # Sort them by log-level results:
+        for check_group in [fatal_checks, experimental_checks, other_checks]:
+            for k in check_group:
+                check_group[k] = sorted(
+                    check_group[k], key=lambda c: c["result"], reverse=True
+                )
+
         return self.template_engine().render(
             fb_version=version,
             summary={k: data["result"][k] for k in LOGLEVELS},


### PR DESCRIPTION
Restablish ordering of results on github markdown reports, showing the more severe results (such as FAILs) at the top.

(issue #4600)