### PR TITLE
Set exit code when called from __main__.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
     - v0.12.0a6 (2024-Apr-04)
     - v0.12.0a7 (2024-Apr-04)
   - Restablish ordering of results on github markdown reports, showing the more severe results (such as FAILs) at the top. (issue #4600)
+  - Set exit code when called from `__main__.py`. (issue #4633)
 
 ### Changes to existing checks
 #### On the Universal profile

--- a/Lib/fontbakery/__main__.py
+++ b/Lib/fontbakery/__main__.py
@@ -1,4 +1,5 @@
+import sys
 import fontbakery.cli
 
 if __name__ == "__main__":
-    fontbakery.cli.main()
+    sys.exit(fontbakery.cli.main())


### PR DESCRIPTION
Fixes https://github.com/fonttools/fontbakery/issues/4633


## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

