### PR TITLE
Temporarily pin glyphsets dependency to version v0.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 
 ## Upcoming release: 0.12.1 (2024-Apr-??)
-  - ...
+  - Temporarily pin glyphsets dependency to version v0.6.17 until a failing assert is addressed (issue #4639)
 
 
 ## 0.12.0 (2024-Apr-12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ googlefontsalwayslatest = [
 	"axisregistry >= 0.4.9, == 0.4.*",
 	"gflanguages >= 0.5.17, == 0.5.*",
 	"gfsubsets >= 2024.2.5",
-	"glyphsets >= 0.6.17, == 0.6.*",
+	"glyphsets == 0.6.17",  # temporarily pinned due to issue #4639  # "glyphsets >= 0.6.19, == 0.6.*",
 	"shaperglot >= 0.5.0, == 0.5.*",
 ]
 


### PR DESCRIPTION
until a failing assert is addressed.
(issue #4639)