### PR TITLE
Negate sense of negative widths comment

### DIFF
--- a/Lib/fontbakery/checks/opentype/os2.py
+++ b/Lib/fontbakery/checks/opentype/os2.py
@@ -86,8 +86,12 @@ def com_google_fonts_check_xavgcharwidth(ttFont):
         for width, _ in ttFont[
             "hmtx"
         ].metrics.values():  # At least .notdef must be present.
-            # The OpenType spec doesn't exclude negative widths, but only positive
-            # widths seems to be the assumption in the wild?
+            # The OpenType spec excludes negative widths (the
+            # relevant field in `hmtx` tables is unsigned);
+            # other formats (UFO) may allow signed, and
+            # therefore negative, widths.
+            # For extra reassurance, here we only count strictly
+            # positive widths.
             if width > 0:
                 count += 1
                 width_sum += width


### PR DESCRIPTION
## Description

The comment previously said "The OpenType spec doesn't exclude negative widths" but actually the OpenType spec _does_ exclude negative widths, and i couldn't really let that stand.

## Checklist
- [x] update `CHANGELOG.md` [i don't think it needs a CHANGELOG]
- [x] wait for the tests to pass
- [x] request a review

