### PR TITLE
Make is_bold condition work with more style naming formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## Upcoming release: 0.12.4 (2024-Apr-22)
-  - ...
+## Upcoming release: 0.12.4 (2024-Apr-??)
+### Changes to existing checks
+#### On the FontWerk profile
+ - **[com.fontwerk/check/style_linking]:** (also included in the `Type Network` profile). Adjust the `is_bold` condition to check for bold-adjacent style names with spaces, such as "Semi Bold" and "Extra Bold", and not consider such styles as "Bold" in the RIBBI sense. (issue #4667)
 
 
 ## 0.12.3 (2024-Apr-22)

--- a/Lib/fontbakery/testable.py
+++ b/Lib/fontbakery/testable.py
@@ -218,13 +218,19 @@ class Font(Testable):
     @cached_property
     def is_bold(self):
         from fontbakery.constants import FsSelection, MacStyle
-        from fontbakery.utils import keyword_in_full_font_name
+        from fontbakery.utils import (
+            keyword_in_full_font_name,
+            bold_adjacent_styles_in_full_font_name,
+        )
 
         ttFont = self.ttFont
         return (
             ("OS/2" in ttFont and ttFont["OS/2"].fsSelection & FsSelection.BOLD)
             or ("head" in ttFont and ttFont["head"].macStyle & MacStyle.BOLD)
-            or keyword_in_full_font_name(ttFont, "bold")
+            or (
+                keyword_in_full_font_name(ttFont, "bold")
+                and not bold_adjacent_styles_in_full_font_name(ttFont)
+            )
         )
 
 

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -651,6 +651,25 @@ def keyword_in_full_font_name(ttFont, keyword):
     return False
 
 
+def bold_adjacent_styles_in_full_font_name(ttFont):
+    from fontbakery.constants import NameID
+
+    for entry in ttFont["name"].names:
+        if entry.nameID == NameID.FULL_FONT_NAME and any(
+            x in entry.string.decode(entry.getEncoding()).lower()
+            for x in [
+                "extra bold",
+                "extrabold",
+                "semi bold",
+                "semibold",
+                "demi bold",
+                "demibold",
+            ]
+        ):
+            return True
+    return False
+
+
 def show_inconsistencies(dictionary, config):
     """Display an 'inconsistencies dictionary' as a bullet list. Turns:
 


### PR DESCRIPTION
## Description
Relates to issue https://github.com/fonttools/fontbakery/issues/4667

Changes:
- Add a util to check if a bold-adjacent style name (such as `Semi Bold` or `SemiBold`) is in a font’s full name, `bold_adjacent_styles_in_full_font_name()`
- Adjust the `is_bold` condition to check for bold-adjacent style names, and not consider such styles as "Bold" in the RIBBI sense

If this is an acceptable change, I can update the changelog, etc. I’m partly submitting this so I can present a proposed solution, rather than just a complaint.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

