### PR TITLE
python 3.8 and 3.9 are currently not available on macos-latest

### DIFF
--- a/.github/workflows/install_run.yml
+++ b/.github/workflows/install_run.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         profile:
           - description: Universal profile on a static font
             name: universal

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
(issue #4673)