### PR TITLE
Fix markdown table formatting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## Upcoming release: 0.12.4 (2024-Apr-??)
 ### Changes to existing checks
+#### On the Google Fonts profile
+  - **[com.google.fonts/check/fvar_instances]:** Fix markdown table formatting. (issue #4675)
+
 #### On the FontWerk profile
- - **[com.fontwerk/check/style_linking]:** (also included in the `Type Network` profile). Adjust the `is_bold` condition to check for bold-adjacent style names with spaces, such as "Semi Bold" and "Extra Bold", and not consider such styles as "Bold" in the RIBBI sense. (issue #4667)
+  - **[com.fontwerk/check/style_linking]:** (also included in the `Type Network` profile). Adjust the `is_bold` condition to check for bold-adjacent style names with spaces, such as "Semi Bold" and "Extra Bold", and not consider such styles as "Bold" in the RIBBI sense. (issue #4667)
 
 
 ## 0.12.3 (2024-Apr-22)

--- a/Lib/fontbakery/checks/googlefonts/varfont.py
+++ b/Lib/fontbakery/checks/googlefonts/varfont.py
@@ -113,7 +113,7 @@ def com_google_fonts_check_stat(ttFont, expected_font_names):
     if font_axis_values != expected_axis_values:
         yield FAIL, Message(
             "bad-axis-values",
-            f"Compulsory STAT Axis Values are incorrect:\n\n {md_table}\n",
+            f"Compulsory STAT Axis Values are incorrect:\n\n{md_table}\n\n",
         )
 
 
@@ -182,14 +182,16 @@ def com_google_fonts_check_fvar_instances(ttFont, ttFonts):
         if wght_wrong:
             hints += "- wght coordinates are wrong for some instances"
         yield FAIL, Message(
-            "bad-fvar-instances", f"fvar instances are incorrect:\n{hints}\n{md_table}"
+            "bad-fvar-instances",
+            f"fvar instances are incorrect:\n\n" f"{hints}\n\n{md_table}\n\n",
         )
     elif any(font_instances[i] != expected_instances[i] for i in same):
         yield WARN, Message(
             "suspicious-fvar-coords",
-            "fvar instance coordinates for non-wght axes are not the same as the fvar"
-            " defaults. This may be intentional so please check with the font author:"
-            f"\n\n{md_table}",
+            f"fvar instance coordinates for non-wght axes are not the same as"
+            f" the fvar defaults. This may be intentional so please check with"
+            f" the font author:\n\n"
+            f"{md_table}\n\n",
         )
 
 


### PR DESCRIPTION
**com.google.fonts/check/fvar_instances**
On the Google Fonts profile.

(issue #4675)