### PR TITLE
Downgrade "caretslope-mismatch" from FAIL to WARN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ A more detailed list of changes is available in the corresponding milestones for
 - Fix bug where some checks would modify the font under test and make other checks fail (issue #4678)
 
 ### Changes to existing checks
+#### On the OpenType profile
+  - **[com.google.fonts/check/caret_slope]:** Downgrade "caretslope-mismatch" from FAIL to WARN. (issue #4679)
+
 #### On the Google Fonts profile
   - **[com.google.fonts/check/fvar_instances]:** Fix markdown table formatting. (issue #4675)
 

--- a/Lib/fontbakery/checks/opentype/hhea.py
+++ b/Lib/fontbakery/checks/opentype/hhea.py
@@ -1,5 +1,5 @@
 from fontbakery.callable import check
-from fontbakery.status import FAIL
+from fontbakery.status import WARN, FAIL
 from fontbakery.message import Message
 
 
@@ -81,7 +81,7 @@ def com_google_fonts_check_caret_slope(ttFont):
         expectedCaretSlopeRise = upm
 
     if abs(postItalicAngle - hheaItalicAngle) > 0.1:
-        yield FAIL, Message(
+        yield WARN, Message(
             "caretslope-mismatch",
             "hhea.caretSlopeRise and hhea.caretSlopeRun"
             " do not match with post.italicAngle.\n"

--- a/tests/checks/opentype/hhea_test.py
+++ b/tests/checks/opentype/hhea_test.py
@@ -1,6 +1,6 @@
 from fontTools.ttLib import TTFont
 
-from fontbakery.status import FAIL
+from fontbakery.status import WARN, FAIL
 from fontbakery.codetesting import (
     assert_PASS,
     assert_results_contain,
@@ -35,10 +35,10 @@ def test_check_caretslope():
     ttFont = TTFont(TEST_FILE("shantell/ShantellSans[BNCE,INFM,SPAC,wght].ttf"))
     assert_PASS(check(ttFont))
 
-    # FAIL for right-leaning
+    # WARN for right-leaning
     ttFont = TTFont(TEST_FILE("shantell/ShantellSans-Italic[BNCE,INFM,SPAC,wght].ttf"))
     ttFont["post"].italicAngle = -12
-    message = assert_results_contain(check(ttFont), FAIL, "caretslope-mismatch")
+    message = assert_results_contain(check(ttFont), WARN, "caretslope-mismatch")
     assert message == (
         "hhea.caretSlopeRise and hhea.caretSlopeRun"
         " do not match with post.italicAngle.\n"
@@ -57,9 +57,9 @@ def test_check_caretslope():
     # Fix it again from backed up good value
     ttFont["hhea"].caretSlopeRise = good_value
 
-    # FAIL for left-leaning
+    # WARN for left-leaning
     ttFont["post"].italicAngle = 12
-    message = assert_results_contain(check(ttFont), FAIL, "caretslope-mismatch")
+    message = assert_results_contain(check(ttFont), WARN, "caretslope-mismatch")
     assert message == (
         "hhea.caretSlopeRise and hhea.caretSlopeRun"
         " do not match with post.italicAngle.\n"


### PR DESCRIPTION
**com.google.fonts/check/caret_slope**
On the `OpenType` profile.

(issue #4679)