### PR TITLE
Fix ERROR in check/missing_small_caps_glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Google Fonts profile
   - **[com.google.fonts/check/fvar_instances]:** Fix markdown table formatting. (issue #4675)
+  - **[com.google.fonts/check/missing_small_caps_glyphs]:** Fix ERROR: Handle LookupType 2, which maps to more than a single glyph. (issue #4677)
 
 #### On the FontWerk profile
   - **[com.fontwerk/check/style_linking]:** (also included in the `Type Network` profile). Adjust the `is_bold` condition to check for bold-adjacent style names with spaces, such as "Semi Bold" and "Extra Bold", and not consider such styles as "Bold" in the RIBBI sense. (issue #4667)

--- a/Lib/fontbakery/checks/googlefonts/glyphset.py
+++ b/Lib/fontbakery/checks/googlefonts/glyphset.py
@@ -305,13 +305,19 @@ def com_google_fonts_check_missing_small_caps_glyphs(ttFont):
                         subtable = subtable.ExtSubTable
                     if not hasattr(subtable, "mapping"):
                         continue
-                    smcp_glyphs = set(subtable.mapping.values())
+                    smcp_glyphs = set()
+                    for value in subtable.mapping.values():
+                        if isinstance(value, list):
+                            for v in value:
+                                smcp_glyphs.add(v)
+                        else:
+                            smcp_glyphs.add(value)
                     missing = smcp_glyphs - set(ttFont.getGlyphNames())
                     if missing:
                         missing = "\n\t - " + "\n\t - ".join(missing)
                         yield FAIL, Message(
                             "missing-glyphs",
-                            f"These '{tag}' glyphs are missing:\n" f"{missing}",
+                            f"These '{tag}' glyphs are missing:\n\n{missing}",
                         )
                 break
 


### PR DESCRIPTION
Handle LookupType 2, which maps to more than a single glyph.

**com.google.fonts/check/missing_small_caps_glyphs**
On the `Google Fonts` profile.

(issue #4677)