### PR TITLE
WIP Eager-load fonts while protected by a lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.5 (2024-May-??)
+  - When multi-threading is enabled, we now ensure that the font objects are fully loaded before running the checks. This causes an initial delay but avoids some code concurrency issues. (issue #4638)
+
 ### Changes to existing checks
 #### On the OpenType profile
   - **[com.google.fonts/check/monospace]:** Fix ERROR when accessing the 4th bit of panose (spacing) when family type is LATIN_HAND_WRITTEN or LATIN_SYMBOL. FontTools still calls it 'bProportion' even though the proper name should be 'bSpacing' (issue #2857)

--- a/Lib/fontbakery/cli.py
+++ b/Lib/fontbakery/cli.py
@@ -456,7 +456,10 @@ def main():
         )
     )
 
+    is_async = args.multiprocessing != 0
+
     context = setup_context(args.files)
+    context.is_multithreaded = is_async
     try:
         runner = CheckRunner(
             profile, jobs=args.multiprocessing, context=context, config=configuration
@@ -466,7 +469,6 @@ def main():
         argument_parser.print_usage()
         sys.exit(1)
 
-    is_async = args.multiprocessing != 0
     if not args.loglevels:
         args.loglevels = [
             status

--- a/Lib/fontbakery/testable.py
+++ b/Lib/fontbakery/testable.py
@@ -76,7 +76,15 @@ class Font(Testable):
 
     @cached_property
     def ttFont(self):
-        return TTFont(self.file)
+        font = TTFont(self.file)
+        if (
+            hasattr(self, "context")
+            and self.context is not None
+            and self.context.is_multithreaded
+        ):
+            # Preload all tables while we're in this cached_property that uses locking
+            font.ensureDecompiled()
+        return font
 
     @cached_property
     def style(self):
@@ -258,6 +266,7 @@ FILE_TYPES = [Readme, Ufo, Designspace, GlyphsFile, MetadataPB, Font]
 class CheckRunContext:
     testables: List[Testable] = field(default_factory=list)
     config: dict = field(default_factory=dict)
+    is_multithreaded: bool = False
 
     @cached_property
     def testables_by_type(self):


### PR DESCRIPTION
## Description
This is a draft to propose an idea to fix #4638 

I'm eager-loading all tables of the ttFont under test while we're opening the ttFont in a cached_property, because that decorator uses proper locking. In my previously failing test with `--auto-jobs`, this now completes the run without errors, however it introduces a long pause at the start of execution before running any test, presumably while the whole font gets loaded.

An alternative solution would be to introduce locking in fontTools, so that lazy-loading a single table has a lock on that entry in the TTFont table cache. That way, only the tables actually needed by tests would get loaded.

It could be interesting to try also with deepcopy; and yet another idea could be that the getter would need to be cached per-thread instead of globally, i.e. use thread-local storage for the caching of cached_property, and so have one ttFont instance per thread. There would be duplicated work to load tables but each thread would have its own copy so hopefully they wouldn't step on each other's toes, and possibly each thread would only load the few tables that the checks running in that thread will use.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

