### PR TITLE
Allow using vharbuzz 0.3.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 	"requests",
 	"beziers >= 0.5.0, == 0.5.*",
 	"uharfbuzz",
-	"vharfbuzz >= 0.2.0, == 0.2.*",
+	"vharfbuzz >= 0.2.0",
     "typing_extensions ; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
It is not clear why we are allowing only 0.2.*, since we don’t seem to use any API that was removed in 0.3.0, and all the tests pass.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

