### PR TITLE
Fix check/monospace ERROR: bSpacing attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.5 (2024-May-??)
-  - ...
+### Changes to existing checks
+#### On the OpenType profile
+  - **[com.google.fonts/check/monospace]:** Fix ERROR when accessing the 4th bit of panose (spacing) when family type is LATIN_HAND_WRITTEN or LATIN_SYMBOL. FontTools still calls it 'bProportion' even though the proper name should be 'bSpacing' (issue #2857)
 
 
 ## 0.12.4 (2024-Apr-26)

--- a/Lib/fontbakery/checks/opentype/name.py
+++ b/Lib/fontbakery/checks/opentype/name.py
@@ -91,7 +91,11 @@ def PANOSE_is_monospaced(panose):
         PANOSE_Family_Type.LATIN_HAND_WRITTEN,
         PANOSE_Family_Type.LATIN_SYMBOL,
     ]:
-        return panose.bSpacing == PANOSE_Spacing.MONOSPACED
+        # NOTE: fonttools has fixed nomenclature for the panose digits,
+        #       regardless of context. So, semantically, here the 4th digit
+        #       should be called bSpacing, but fonttools still gives it
+        #       the 'bProportion' attribute name.
+        return panose.bProportion == PANOSE_Spacing.MONOSPACED
 
     # otherwise
     return False


### PR DESCRIPTION
**com.google.fonts/check/monospace**
On the OpenType profile

Fix ERROR when accessing the 4th bit of panose (spacing) when family type is LATIN_HAND_WRITTEN or LATIN_SYMBOL. FontTools still calls it 'bProportion' even though the proper name should be 'bSpacing'.

(issue #2857)