### PR TITLE
Reintroduce the `--list-subcommands` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## Upcoming release: 0.12.5 (2024-May-??)
   - When multi-threading is enabled, we now ensure that the font objects are fully loaded before running the checks. This causes an initial delay but avoids some code concurrency issues. (issue #4638)
+  - Add back the `--list-subcommands` option that had been removed by mistake on v0.12.0 (issue #4685)
 
 ### Changes to existing checks
 #### On the OpenType profile

--- a/Lib/fontbakery/cli.py
+++ b/Lib/fontbakery/cli.py
@@ -83,13 +83,16 @@ def ArgumentParser():
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
+    argument_parser.add_argument(
+        "--list-subcommands",
+        action="store_true",
+        help="print list of supported subcommands",
+    )
     argument_parser.add_argument("--version", action="version", version=__version__)
     subcommands = ["check-profile"] + ["check_" + prof for prof in CLI_PROFILES]
     subcommands = [command.replace("_", "-") for command in sorted(subcommands)]
 
-    subparsers = argument_parser.add_subparsers(
-        dest="command", help="sub-command help", required=True
-    )
+    subparsers = argument_parser.add_subparsers(dest="command")
 
     for subcommand in subcommands:
         subparser = subparsers.add_parser(
@@ -102,6 +105,8 @@ def ArgumentParser():
                 metavar="PROFILE",
             )
         add_profile_arguments(subparser)
+
+    argument_parser.subcommands = subcommands
     return argument_parser
 
 
@@ -413,6 +418,13 @@ def main():
         print(e)
         argument_parser.print_usage()
         sys.exit(1)
+
+    if args.list_subcommands:
+        print(" ".join(argument_parser.subcommands))
+        sys.exit(0)
+    elif args.command is None:
+        argument_parser.print_usage()
+        sys.exit(2)
 
     theme = get_theme(args)
 


### PR DESCRIPTION
Add back the `--list-subcommands` option that had been removed by mistake on the v0.12.0 release.

(issue #4685)