### PR TITLE
Improve tabular_kerning check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/varfont/family_axis_ranges]:** Updated the check to skip fonts without fvar tables. (issue #4554)
   - **[com.google.fonts/check/xavgcharwidth]:** Added rationale. Also, when glyphs needed to compute xAvgCharWidth are missing, it is considered critical, so it is now results in a FATAL-level result. (PR #4570)
 
+#### On the Universal Profile
+  - **[com.google.fonts/check/tabular_kerning]:** Eliminated false positives and other errors (issue #4640)
+
 
 ## 0.12.0a2 (2024-Feb-21)
   - **[multi-threading]:** Lock reporting when returning results. (issue #4494)

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -1293,15 +1293,14 @@ def test_check_math_tabular_kerning():
     font = TEST_FILE("hinting/Roboto-VF.ttf")
     assert_results_contain(check(font), FAIL, "has-tabular-kerning")
 
+    font = TEST_FILE("amiri/AmiriQuranColored.ttf")
+    assert_results_contain(check(font), FAIL, "has-tabular-kerning")
+
     # Ubuntu Sans has digraphs (like DZ) that get decomposed in ccmp
     # and then have kerning between the individual D and Z, which
     # used to throw off the check
     font = TEST_FILE("ubuntusans/UbuntuSans[wdth,wght].ttf")
     assert_PASS(check(font))
-    # This currently shows false positives:
-    # TODO: Fix this and turn this into an assert_PASS
-    font = TEST_FILE("ubuntusans/UbuntuSans-Italic[wdth,wght].ttf")
-    assert_results_contain(check(font), FAIL, "has-tabular-kerning")
 
 
 def test_check_linegaps():


### PR DESCRIPTION
## Description
Relates to issue #4640

Eliminated false positives and other errors. 
Particularly FAILs are down from 147 to 103.

Before (entire GF library):
![Bildschirmfoto 2024-05-02 um 15 41 37](https://github.com/fonttools/fontbakery/assets/175386/c4641458-c65d-432b-b39d-d97ae29bd06d)

After:
![Bildschirmfoto 2024-05-02 um 14 52 19](https://github.com/fonttools/fontbakery/assets/175386/77193cd7-5e24-4fe4-ae98-c2e8112d2a11)



## Checklist
- [X] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

Fixes #4640

