### PR TITLE
Fix ordering of log-messages on reports to show FAILs at the top.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 0.12.5 (2024-May-??)
   - When multi-threading is enabled, we now ensure that the font objects are fully loaded before running the checks. This causes an initial delay but avoids some code concurrency issues. (issue #4638)
   - Add back the `--list-subcommands` option that had been removed by mistake on v0.12.0 (issue #4685)
+  - Fix ordering of log-messages on reports to show FAILs at the top. (issue #4672)
 
 ### Changes to existing checks
 #### On the OpenType profile

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -57,10 +57,11 @@ class GHMarkdownReporter(HTMLReporter):
                         other_checks[key].append(check)
 
         # Sort them by log-level results:
+        ordering = ["ERROR", "FATAL", "FAIL", "WARN", "INFO", "PASS", "SKIP"]
         for check_group in [fatal_checks, experimental_checks, other_checks]:
             for k in check_group:
                 check_group[k] = sorted(
-                    check_group[k], key=lambda c: c["result"], reverse=True
+                    check_group[k], key=lambda c: ordering.index(c["result"])
                 )
 
         return self.template_engine().render(


### PR DESCRIPTION
(issue #4672)