### PR TITLE
Glyphsets v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ googlefontsalwayslatest = [
 	"axisregistry >= 0.4.9, == 0.4.*",
 	"gflanguages >= 0.5.17, == 0.5.*",
 	"gfsubsets >= 2024.2.5",
-	"glyphsets >= 1.0.0, == 1.*.*",
+	"glyphsets >= 1.0.0, == 1.*",
 	"shaperglot >= 0.5.0, == 0.5.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ ufo2ft = [
 # deal with API-breaking updates. Only the latest released version is acceptable:
 googlefontsalwayslatest = [
 	"axisregistry >= 0.4.9, == 0.4.*",
-	"gflanguages >= 0.5.17, == 0.5.*",
+	"gflanguages >= 0.6.0, == 0.6.*",
 	"gfsubsets >= 2024.2.5",
 	"glyphsets >= 1.0.0, == 1.*",
 	"shaperglot >= 0.5.0, == 0.5.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ googlefontsalwayslatest = [
 	"axisregistry >= 0.4.9, == 0.4.*",
 	"gflanguages >= 0.5.17, == 0.5.*",
 	"gfsubsets >= 2024.2.5",
-	"glyphsets >= 0.6.20, == 0.6.*",
+	"glyphsets >= 1.0.0, == 1.*.*",
 	"shaperglot >= 0.5.0, == 0.5.*",
 ]
 


### PR DESCRIPTION
No API changes, but finalized `glyphsets v1.0.0`, so will use adult semver from now on.
The `gflanguages` update also happened in the meantime and broke the CI, so I had to update that as well.