### PR TITLE
Don't change working directory during `git_rootdir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.6 (2024-May-??)
-  - ...
+  - Fixed race condition with `--auto-jobs` caused by the current working directory changing (issue #4700)
 
 
 ## 0.12.5 (2024-May-03)

--- a/Lib/fontbakery/checks/googlefonts/license.py
+++ b/Lib/fontbakery/checks/googlefonts/license.py
@@ -14,20 +14,17 @@ def git_rootdir(family_dir):
     if not family_dir:
         return None
 
-    original_dir = os.getcwd()
     root_dir = None
     import subprocess
 
     try:
-        os.chdir(family_dir)
-        git_cmd = ["git", "rev-parse", "--show-toplevel"]
+        git_cmd = ["git", "-C", family_dir, "rev-parse", "--show-toplevel"]
         git_output = subprocess.check_output(git_cmd, stderr=subprocess.STDOUT)
         root_dir = git_output.decode("utf-8").strip()
 
     except (OSError, IOError, subprocess.CalledProcessError):
         pass  # Not a git repo, or git is not installed.
 
-    os.chdir(original_dir)
     return root_dir
 
 


### PR DESCRIPTION
## Description

Fixes #4700 

Applies the recommended fix to have the git subprocess handle directory changing, instead of changing directory for the whole process (including other jobs currently in progress when `--auto-jobs` is used)

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

