### PR TITLE
Re-enabled legacy_accents check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Universal profile
   - **[com.google.fonts/check/tabular_kerning]:** Fixed race condition / bug where the check would modify the cmap of the font being checked (issue #4697)
+  - **[com.google.fonts/check/legacy_accents]:** Re-enabled check but dropped complaints about legacy accents as part of glyph compositions (issue #4567)
 
 #### On the Google Fonts profile
   - **[com.google.font/check/description/has_article]:** yield INFO when a non-Noto font doesn' t have an article. Also, an empty description file is not needed anymore (issue #4702)
-
 
 ## 0.12.5 (2024-May-03)
   - When multi-threading is enabled, we now ensure that the font objects are fully loaded before running the checks. This causes an initial delay but avoids some code concurrency issues. (issue #4638)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -20,7 +20,7 @@ PROFILE = {
             "com.adobe.fonts/check/freetype_rasterizer",
             "com.google.fonts/check/gpos7",
             "com.google.fonts/check/interpolation_issues",
-            # "com.google.fonts/check/legacy_accents",  # Disabled: issue #3595 / PR #4567
+            "com.google.fonts/check/legacy_accents",
             "com.google.fonts/check/linegaps",
             "com.google.fonts/check/mandatory_glyphs",
             "com.google.fonts/check/math_signs_width",

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -583,7 +583,7 @@ def test_check_whitespace_ink():
     )
 
 
-def DISABLED_test_check_legacy_accents():
+def test_check_legacy_accents():
     """Check that legacy accents aren't used in composite glyphs."""
     check = CheckTester("com.google.fonts/check/legacy_accents")
 
@@ -599,12 +599,6 @@ def DISABLED_test_check_legacy_accents():
     )
 
     test_font = TTFont(TEST_FILE("lugrasimo/Lugrasimo-Regular.ttf"))
-    assert_results_contain(
-        check(test_font),
-        WARN,
-        "legacy-accents-component",
-        "for legacy accents being used in composites.",
-    )
     assert_results_contain(
         check(test_font),
         FAIL,


### PR DESCRIPTION
## Description
Re-enabled check but dropped complaints about legacy accents as part of glyph compositions
Relates to issue #4567

The two messages `legacy-accents-width` and `legacy-accents-gdef` are critical and should not have been disabled in my opinion.

Since the check was disabled rather than outright deleted, I interpret from this that back then there was no time to look into the matter in detail, and so I took the initiative to completely remove the `legacy-accents-component` WARN part but otherwise re-enabled the check as it was to still yield FAIL on the two other messages.

## Checklist
- [X] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

