### PR TITLE
Fix cmap changing in `ttFont` under test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.6 (2024-May-??)
+  - Fixed race condition / bug where [com.google.fonts/check/tabular_kerning] would modify the cmap of the font being tested
   - ...
 
 

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -2424,8 +2424,8 @@ def com_google_fonts_check_tabular_kerning(ttFont):
                 add_cmap(ttFont, PUA, glyph_name)
                 cmap_unicodes.append(PUA)
 
-    # Copy of ttFont because we're changing data
-    ttFont_copy = copy.copy(ttFont)
+    # Deep copy of ttFont because we're changing data
+    ttFont_copy = copy.deepcopy(ttFont)
     add_PUA_unicode(ttFont_copy)
     vhb = Vharfbuzz(ttFont.reader.file.name)
     best_cmap = ttFont_copy.getBestCmap()


### PR DESCRIPTION
## Description
Relates to race condition issues with `--auto-jobs`

Deep copies the `ttFont` in `com.google.fonts/check/tabular_kerning` so the cmap modifications don't trip up other tests. In our case, I saw `com.google.fonts/check/soft_dotted` crash because the cmap was changed while it was being iterated through

For the nuance between copy and deepcopy, see: https://docs.python.org/3/library/copy.html

Props to @Hoolean for correctly guessing and then spotting this issue from an awful stack trace in a one-off error

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

