### PR TITLE
update description/has_article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.6 (2024-May-??)
-  - ...
+### Changes to existing checks
+#### On the Google Fonts profile
+  - **[com.google.font/check/description/has_article]:** yield INFO when a non-Noto font doesn' t have an article. Also, an empty description file is not needed anymore (issue #4702)
 
 
 ## 0.12.5 (2024-May-03)

--- a/Lib/fontbakery/checks/googlefonts/description.py
+++ b/Lib/fontbakery/checks/googlefonts/description.py
@@ -68,44 +68,53 @@ def github_gfonts_description(font: Font, network):
     proposal=[
         "https://github.com/fonttools/fontbakery/issues/3841",
         "https://github.com/fonttools/fontbakery/issues/4318",
+        "https://github.com/fonttools/fontbakery/issues/4702",
     ],
 )
 def com_google_fonts_check_description_has_article(font):
     """Check for presence of an ARTICLE.en_us.html file"""
     directory = os.path.dirname(font.file)
     article_path = os.path.join(directory, "article", "ARTICLE.en_us.html")
+    description_path = os.path.join(directory, "DESCRIPTION.en_us.html")
     has_article = os.path.exists(article_path)
+    has_description = os.path.exists(description_path)
     article_is_empty = has_article and os.path.getsize(article_path) == 0
-    description_is_empty = not font.description
+    description_is_empty = has_description and os.path.getsize(description_path) == 0
 
-    if not font.is_noto and has_article:
-        if not description_is_empty:
+    if not font.is_noto:
+        if not has_article:
+            yield INFO, Message(
+                "missing-article",
+                "This font doesn't have an ARTICLE.en_us.html file.",
+            )
+        else:
+            if article_is_empty:
+                yield FAIL, Message(
+                    "empty-article",
+                    "The ARTICLE.en_us.html file is empty.",
+                )
+            if has_description:
+                yield FAIL, Message(
+                    "description-and-article",
+                    "This font has both a DESCRIPTION.en_us.html file"
+                    " and an ARTICLE.en_us.html file. In this case the"
+                    " description must be deleted.",
+                )
+    elif font.is_noto:
+        if not has_article:
             yield FAIL, Message(
-                "description-and-article",
-                "This font has both a DESCRIPTION.en_us.html file"
-                " and an ARTICLE.en_us.html file. In this case the"
-                " description must be empty.",
+                "missing-article",
+                "This is a Noto font but it lacks an ARTICLE.en_us.html file.",
             )
         if article_is_empty:
             yield FAIL, Message(
                 "empty-article",
                 "The ARTICLE.en_us.html file is empty.",
             )
-    elif font.is_noto:
-        if not has_article:
+        if not has_description or description_is_empty:
             yield FAIL, Message(
-                "missing-article",
-                "This is a Noto font but it lacks an ARTICLE.en_us.html file",
-            )
-        if has_article and article_is_empty:
-            yield FAIL, Message(
-                "empty-article",
-                "The ARTICLE.en_us.html file is empty.",
-            )
-        if not font.description or description_is_empty:
-            yield FAIL, Message(
-                "empty-description",
-                "This is a Noto font but it lacks a DESCRIPTION.en_us.html file",
+                "missing-description",
+                "This is a Noto font but it lacks a DESCRIPTION.en_us.html file.",
             )
 
 

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -4752,7 +4752,7 @@ def test_check_empty_glyph_on_gid1_for_colrv0():
     )
 
 
-def test_check_has_article():
+def test_check_description_has_article():
     """Noto fonts must have an ARTICLE.en_us.html file, others with an
     article should have an empty DESCRIPTION"""
     check = CheckTester("com.google.fonts/check/description/has_article")


### PR DESCRIPTION
- yield INFO when a non-Noto font doesn' t have an article
- an empty description file is not needed anymore

**com.google.fonts/check/description/has_article**
On the `Google Fonts` profile.

(issue #4702)