### PR TITLE
Don't change working directory during git_rootdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.6 (2024-May-??)
+  - Fixed race condition with `--auto-jobs` caused by the current working directory changing (issue #4700)
+
 ### Changes to existing checks
 #### On the Google Fonts profile
   - **[com.google.font/check/description/has_article]:** yield INFO when a non-Noto font doesn' t have an article. Also, an empty description file is not needed anymore (issue #4702)

--- a/Lib/fontbakery/checks/googlefonts/license.py
+++ b/Lib/fontbakery/checks/googlefonts/license.py
@@ -14,20 +14,17 @@ def git_rootdir(family_dir):
     if not family_dir:
         return None
 
-    original_dir = os.getcwd()
     root_dir = None
     import subprocess
 
     try:
-        os.chdir(family_dir)
-        git_cmd = ["git", "rev-parse", "--show-toplevel"]
+        git_cmd = ["git", "-C", family_dir, "rev-parse", "--show-toplevel"]
         git_output = subprocess.check_output(git_cmd, stderr=subprocess.STDOUT)
         root_dir = git_output.decode("utf-8").strip()
 
     except (OSError, IOError, subprocess.CalledProcessError):
         pass  # Not a git repo, or git is not installed.
 
-    os.chdir(original_dir)
     return root_dir
 
 


### PR DESCRIPTION
Fixed race condition with `--auto-jobs` caused by the current working directory changing.

(issue #4700)