### PR TITLE
Fix cmap changing in ttFont being checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - Fixed race condition with `--auto-jobs` caused by the current working directory changing (issue #4700)
 
 ### Changes to existing checks
+#### On the Universal profile
+  - **[com.google.fonts/check/tabular_kerning]:** Fixed race condition / bug where the check would modify the cmap of the font being checked (issue #4697)
+
 #### On the Google Fonts profile
   - **[com.google.font/check/description/has_article]:** yield INFO when a non-Noto font doesn' t have an article. Also, an empty description file is not needed anymore (issue #4702)
 

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -2424,8 +2424,8 @@ def com_google_fonts_check_tabular_kerning(ttFont):
                 add_cmap(ttFont, PUA, glyph_name)
                 cmap_unicodes.append(PUA)
 
-    # Copy of ttFont because we're changing data
-    ttFont_copy = copy.copy(ttFont)
+    # Deep copy of ttFont because we're changing data
+    ttFont_copy = copy.deepcopy(ttFont)
     add_PUA_unicode(ttFont_copy)
     vhb = Vharfbuzz(ttFont.reader.file.name)
     best_cmap = ttFont_copy.getBestCmap()


### PR DESCRIPTION
Fixed race condition / bug where the check would modify the cmap of the font being checked. Deep copies the ttFont so that the cmap modifications don't trip up other checks. In our case, I saw com.google.fonts/check/soft_dotted crash because the cmap was changed while it was being iterated through. For the nuance between copy and deepcopy, see: https://docs.python.org/3/library/copy.html

Props to @Hoolean for correctly guessing and then spotting this issue from an awful stack trace in a one-off error.

**com.google.fonts/check/tabular_kerning**
On the `Universal` profile.

(issue #4697)