### PR TITLE
Bump beziers to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.typenetwork/check/glyph_coverage]:** Added minus sign to min charset. (PR #4701)
   - **[com.typenetwork/check/usweightclass]:** Updated `tn_expected_os2_weight` condition. (issue #4694 / PR #4701)
 
+#### On the Outline profile
+  - **[com.google.fonts/check/outline_direction]:** fixed float division by zero error
+
 
 ## 0.12.5 (2024-May-03)
   - When multi-threading is enabled, we now ensure that the font objects are fully loaded before running the checks. This causes an initial delay but avoids some code concurrency issues. (issue #4638)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 	"packaging",
 	"pip-api",
 	"requests",
-	"beziers >= 0.5.0, == 0.5.*",
+	"beziers >= 0.6.0, == 0.6.*",
 	"uharfbuzz",
 	"vharfbuzz >= 0.2.0",
     "typing_extensions ; python_version < '3.11'",


### PR DESCRIPTION
## Description

Fixes #4699

Bumps `beziers` to a version with the necessary fix

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

