### PR TITLE
Apply most of the description checks to articles as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.7 (2024-May-??)
-
-#### On the Outline profile
+### Changes to existing checks
+#### On the Google Fonts profile (Outline checks)
   - **[com.google.fonts/check/outline_direction]:** fixed an error where the outermost path was not correctly detected. (issue #4719)
+
+#### On the Google Fonts profile
+  - Checks which validate the description files now also validate article files (issue #4730)
+  - **[com.google.font/check/description/unsupported_elements]:** Also checks for wellformedness of HTML video tags (issue #4730)
+
 
 ## 0.12.6 (2024-May-13)
   - Fixed race condition with `--auto-jobs` caused by the current working directory changing (issue #4700)

--- a/data/test/unsupported_html_elements/article/ARTICLE.en_us.html
+++ b/data/test/unsupported_html_elements/article/ARTICLE.en_us.html
@@ -1,0 +1,26 @@
+<p>Danfo, a variable-axis font, is the result of a collaboration between Afrotype and Abu, a lettering artist from Ojota
+  Bus Stop. It is inspired by the cut-out shapes of vinyl sticker lettering on public transportation buses in Lagos,
+  Nigeria. This font, the first project from Afrotype, is an improved version of the 2018 design, now featuring a richer
+  character set that supports all of Sub-Saharan African Latin. Danfo is the base set of a family of Danfo fonts
+  Afrotype plans to release.</p>
+
+<p>To contribute, please see <a href="https://github.com/Afrotype/danfo">github.com/Afrotype/danfo</a>.</p>
+
+<hr />
+<video autoplay="1" muted="1">
+  <source src="01.mp4" type="video/mp4" />
+</video>
+<img src="2.1.jpg" />
+<video autoplay="1" muted="1">
+  <source src="2.2.mp4" type="video/mp4" />
+</video>
+<video autoplay="1" muted="1">
+  <source src="2.3.mp4" type="video/mp4" />
+</video>
+<img src="2.4.jpg" />
+<img src="3.1.jpg" />
+<video autoplay="1" muted="1">
+  <source src="3.2.mp4" type="video/mp4" />
+</video>
+<img src="3.3.jpg" />
+<img src="3.4.jpg" />

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -4845,9 +4845,9 @@ def test_check_description_has_unsupported_elements():
     assert_PASS(check(font))
 
     font = TEST_FILE("unsupported_html_elements/ABeeZee-Regular.ttf")
-    assert_results_contain(
-        check(font), FATAL, "unsupported-elements", "with a bad font"
-    )
+    results = check(font)
+    assert_results_contain(results, FATAL, "unsupported-elements", "with a bad font")
+    assert_results_contain(results, FATAL, "video-tag-needs-src", "with a bad font")
 
 
 def test_check_italic_axis_in_stat_is_boolean():


### PR DESCRIPTION
## Description
Relates to issue #4730

* Applies the description.en_us.html checks to article.en_us.html.
* Checks that video tags have src attributes, a blocker for dev push
 
## Checklist
- [X] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [X] request a review

