### PR TITLE
new check: Validate METADATA.pb `date_added` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.7 (2024-May-??)
+### New checks
+#### Added to the Google Fonts profile
+  - **EXPERIMENTAL - [com.google.fonts/check/metadata/date_added]:** Check that the date_added field is not empty or malformed. (issue #4729)
+
 ### Changes to existing checks
 #### On the Google Fonts profile (Outline checks)
   - **[com.google.fonts/check/outline_direction]:** fixed an error where the outermost path was not correctly detected. (issue #4719)

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -68,6 +68,45 @@ def com_google_fonts_check_metadata_designer_values(family_metadata):
 
 
 @check(
+    id="com.google.fonts/check/metadata/date_added",
+    conditions=["family_metadata"],
+    rationale="""
+        The date_added field must not be empty or malformed.
+
+        Expected format is "YYYY-MM-DD"
+    """,
+    proposal="https://github.com/fonttools/fontbakery/issues/4729",
+    experimental="Since 2024/May/22",
+)
+def com_google_fonts_check_metadata_date_added(family_metadata):
+    """Validate 'date_added' field on METADATA.pb."""
+
+    if not family_metadata.date_added or family_metadata.date_added == "":
+        yield FATAL, Message("empty", "The date_added field is missing or is empty")
+
+    else:
+        elements = family_metadata.date_added.split("-")
+        if not (
+            len(elements) == 3  # year, month and day
+            and len(elements[0]) == 4  #  4 digit year
+            and len(elements[1]) == 2  #  2 digit month
+            and len(elements[2]) == 2  #  2 digit day
+            and int(elements[0]) is not None  # year must be a number
+            and int(elements[1]) is not None  # month must be a number
+            and int(elements[2]) is not None  # day must be a number
+            and 1 <= int(elements[1]) <= 12  # from january to december
+            and 1 <= int(elements[2]) <= 31  # acceptable month days
+        ):
+            # Note: perhaps we could have better/more
+            #       specific validation for the day of month
+            yield FATAL, Message(
+                "malformed",
+                f"The date_added field has invalid format."
+                f" It should be YYYY-MM-DD instead of '{family_metadata.date_added}'",
+            )
+
+
+@check(
     id="com.google.fonts/check/metadata/broken_links",
     conditions=["network", "family_metadata"],
     proposal=[

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -15,6 +15,7 @@ PROFILE = {
             "com.google.fonts/check/metadata/consistent_repo_urls",
             "com.google.fonts/check/metadata/copyright",
             "com.google.fonts/check/metadata/copyright_max_length",
+            "com.google.fonts/check/metadata/date_added",
             "com.google.fonts/check/metadata/designer_profiles",
             "com.google.fonts/check/metadata/designer_values",
             "com.google.fonts/check/metadata/empty_designer",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -663,6 +663,37 @@ def test_check_metadata_designer_values():
     )
 
 
+def test_check_metadata_date_added():
+    """Validate 'date_added' field on METADATA.pb."""
+    check = CheckTester("com.google.fonts/check/metadata/date_added")
+
+    font = TEST_FILE("merriweather/Merriweather-Regular.ttf")
+    assert_PASS(check(font), "with a good METADATA.pb file...")
+
+    md = Font(font).family_metadata
+    md.date_added = "2021-07-11"
+    assert_PASS(
+        check(MockFont(file=font, family_metadata=md)),
+        "with a good date_added field...",
+    )
+
+    md.date_added = ""
+    assert_results_contain(
+        check(MockFont(file=font, family_metadata=md)),
+        FATAL,
+        "empty",
+        "with an empty string on date_added field...",
+    )
+
+    md.date_added = "2020, Oct 1st"  # This is not the YYYY-MM-DD format we expect.
+    assert_results_contain(
+        check(MockFont(file=font, family_metadata=md)),
+        FATAL,
+        "malformed",
+        "with a bad date string on date_added field...",
+    )
+
+
 def test_check_metadata_broken_links():
     """Does DESCRIPTION file contain broken links?"""
     # check = CheckTester("com.google.fonts/check/metadata/broken_links")


### PR DESCRIPTION
On METADATA.pb files, check that the date_added field is not empty or malformed.

* **EXPERIMENTAL - com.google.fonts/check/metadata/date_added**
* Added to the Google Fonts profile.

(issue #4729)