### PR TITLE
[com.google.fonts/check/case_mapping] Only check letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ A more detailed list of changes is available in the corresponding milestones for
   - **EXPERIMENTAL - [com.google.fonts/check/metadata/date_added]:** Check that the date_added field is not empty or malformed. (issue #4729)
 
 ### Changes to existing checks
-#### On the Google Fonts profile (Outline checks)
+#### On the Universal profile
+  - **[com.google.fonts/check/case_mapping]:** Only check letters. As per David Corbett's suggestion, we now check for unicode category = "L*". (issue #4733)
+
+#### On the Outline profile
   - **[com.google.fonts/check/outline_direction]:** fixed an error where the outermost path was not correctly detected. (issue #4719)
 
 #### On the Google Fonts profile
   - Checks which validate the description files now also validate article files (issue #4730)
-  - **[com.google.font/check/description/unsupported_elements]:** Also checks for wellformedness of HTML video tags (issue #4730)
+  - **[com.google.font/check/description/unsupported_elements]:** Also checks for wellformedness of HTML video tags. (issue #4730)
 
 
 ## 0.12.6 (2024-May-13)

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -2795,6 +2795,10 @@ def com_google_fonts_check_case_mapping(ttFont):
         if codepoint in EXCEPTIONS:
             continue
 
+        # Only check letters
+        if unicodedata.category(chr(codepoint))[0] != "L":
+            continue
+
         the_char = chr(codepoint)
         swapped = the_char.swapcase()
 

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -1406,3 +1406,10 @@ def test_check_case_mapping():
     _remove_cmap_entry(ttFont, 0x01E6)
     _remove_cmap_entry(ttFont, 0x01F4)
     assert_PASS(check(ttFont))
+
+    # Let's add something which *does* have case swapping but which isn't a letter
+    # to ensure the check doesn't fail for such glyphs.
+    for table in ttFont["cmap"].tables:
+        table.cmap[0x2160] = "uni2160"  # ROMAN NUMERAL ONE, which downcases to 0x2170
+    assert 0x2170 not in ttFont.getBestCmap()
+    assert_PASS(check(ttFont))


### PR DESCRIPTION
## Description
Relates to issue #4733; as per David Corbett's suggestion, we check for unicode category = "L*"

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [X] request a review

