### PR TITLE
Arrowtype extend "regular coords" conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.font/check/description/unsupported_elements]:** Also checks for wellformedness of HTML video tags. (issue #4730)
   - **[com.google.fonts/check/metadata/copyright_max_length], [com.google.fonts/check/metadata/nameid/copyright], [com.google.fonts/check/metadata/valid_copyright], [com.google.fonts/check/name/copyright_length]:** These checks have all been merged into [com.google.fonts/check/font_copyright]. (PR #4748 / issue #4735)
 
+#### Shared Conditions
+  - Extend "regular coord" conditions to accept "Regular Italic" style name, in addition to "Regular" and "Italic" (PR #4741)
+
 
 ## 0.12.6 (2024-May-13)
   - Fixed race condition with `--auto-jobs` caused by the current working directory changing (issue #4700)

--- a/Lib/fontbakery/checks/shared_conditions.py
+++ b/Lib/fontbakery/checks/shared_conditions.py
@@ -129,6 +129,8 @@ def regular_wght_coord(font):
     ttFont = font.ttFont
     upright = get_instance_axis_value(ttFont, "Regular", "wght")
     italic = get_instance_axis_value(ttFont, "Italic", "wght")
+    if upright is None and italic is None:
+        italic = get_instance_axis_value(ttFont, "Regular Italic", "wght")
     # Note: you cannot simply do `return upright or italic` since `0 or None`
     # will return None in Python.
     return upright if upright is not None else italic
@@ -149,6 +151,8 @@ def regular_wdth_coord(font):
     ttFont = font.ttFont
     upright = get_instance_axis_value(ttFont, "Regular", "wdth")
     italic = get_instance_axis_value(ttFont, "Italic", "wdth")
+    if upright is None and italic is None:
+        italic = get_instance_axis_value(ttFont, "Regular Italic", "wdth")
     # Note: you cannot simply do `return upright or italic` since `0 or None`
     # will return None in Python.
     return upright if upright is not None else italic
@@ -171,6 +175,8 @@ def regular_opsz_coord(font):
     ttFont = font.ttFont
     upright = get_instance_axis_value(ttFont, "Regular", "opsz")
     italic = get_instance_axis_value(ttFont, "Italic", "opsz")
+    if upright is None and italic is None:
+        italic = get_instance_axis_value(ttFont, "Regular Italic", "opsz")
     # Note: you cannot simply do `return upright or italic` since `0 or None`
     # will return None in Python.
     return upright if upright is not None else italic


### PR DESCRIPTION
## Description

While it is common for typefaces to have a Regular Italic style called simply "Italic," it is also common for typefaces to label this style as "Regular Italic" – and arguably, this is more user-friendly in style menus that list many weights, plus Italics.

There are multiple checks that rely on conditions that find the "Regular" instance of an Italic variable font, then use this to determine whether that instance has the correct axis values for weight, width, and optical size. This is great! However, this leads to a lot of false WARNs/FAILs if such a font uses the style name "Regular Italic," instead of simply "Italic."

A bit more context: The shorter name (simply "Italic"), as I understand it, is used to help apps and systems that use style names for RIBBI style linking. However, as I understand it, these systems should continue to work so long as NameID 2 is set to just "Italic" (plus a few factors in tables other than the name table). If a named instance is "Regular Italic," or if NameID 17 is "Regular Italic," it is my understanding and experience that things will still work fine. If I am incorrect in this, I am happy to be corrected.

@felipesanches the PR sidebar doesn’t offer me the option to request a review, so I hereby request a review via text. Please let me know if you have any feedback here! Thanks so much.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

