### PR TITLE
Rationale wording is opposite of what the check actually does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Outline profile
   - **[com.google.fonts/check/outline_direction]:** fixed an error where the outermost path was not correctly detected. (issue #4719)
+  - **[com.google.fonts/check/outline_direction]:** fix wording in rational, it stated the opposite of what the check does. (issue #4743)
 
 #### On the Google Fonts profile
   - Checks which validate the description files now also validate article files (issue #4730)

--- a/Lib/fontbakery/checks/outline.py
+++ b/Lib/fontbakery/checks/outline.py
@@ -330,7 +330,7 @@ def com_google_fonts_check_outline_semi_vertical(ttFont, outlines_dict, config):
     id="com.google.fonts/check/outline_direction",
     rationale="""
         In TrueType fonts, the outermost contour of a glyph should be oriented
-        counter-clockwise, while the inner contours should be oriented clockwise.
+        clockwise, while the inner contours should be oriented counter-clockwise.
         Getting the path direction wrong can lead to rendering issues in some
         software.
     """,


### PR DESCRIPTION
## Description
Relates to issue #4743

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

