### PR TITLE
Merge all GF copyright checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Google Fonts profile
   - Checks which validate the description files now also validate article files (issue #4730)
   - **[com.google.font/check/description/unsupported_elements]:** Also checks for wellformedness of HTML video tags. (issue #4730)
+  - **[com.google.fonts/check/metadata/copyright_max_length], [com.google.fonts/check/metadata/nameid/copyright], [com.google.fonts/check/metadata/valid_copyright], [com.google.fonts/check/name/copyright_length]:** These checks have all been merged into [com.google.fonts/check/font_copyright]. (PR #4748 / issue #4735)
 
 
 ## 0.12.6 (2024-May-13)

--- a/Lib/fontbakery/checks/googlefonts/copyright.py
+++ b/Lib/fontbakery/checks/googlefonts/copyright.py
@@ -1,149 +1,70 @@
-from fontbakery.prelude import check, disable, Message, FAIL
+from collections import defaultdict
+from fontbakery.prelude import check, Message, FAIL
 from fontbakery.checks.googlefonts.constants import (
     DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING,
     EXPECTED_COPYRIGHT_PATTERN,
 )
 from fontbakery.constants import NameID
-
-
-@check(
-    id="com.google.fonts/check/metadata/valid_copyright",
-    conditions=["font_metadata"],
-    rationale="""
-        This check aims at ensuring a uniform and legally accurate copyright statement
-        on the METADATA.pb copyright entries accross the Google Fonts library.
-
-    """
-    + DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING,
-    severity=10,  # max severity because licensing mistakes can cause legal problems.
-    proposal="legacy:check/102",
-)
-def com_google_fonts_check_metadata_valid_copyright(font_metadata):
-    """Copyright notices match canonical pattern in METADATA.pb"""
-    import re
-
-    string = font_metadata.copyright.lower()
-    if not re.search(EXPECTED_COPYRIGHT_PATTERN, string):
-        yield FAIL, Message(
-            "bad-notice-format",
-            f"METADATA.pb: Copyright notices should match a pattern similar to:\n\n"
-            f' "Copyright 2020 The Familyname Project Authors (git url)"\n\n'
-            f'But instead we have got:\n\n"{string}"',
-        )
+from fontbakery.utils import show_inconsistencies
 
 
 @check(
     id="com.google.fonts/check/font_copyright",
     rationale="""
         This check aims at ensuring a uniform and legally accurate copyright statement
-        on the name table entries of font files accross the Google Fonts library.
+        on the name table entries and METADATA.pb files of font files across the Google
+        Fonts library.
+
+        We also check that the copyright field in METADATA.pb matches the
+        contents of the name table nameID 0 (Copyright), and that the copyright
+        notice within the METADATA.pb file is not too long; if it is more than 500
+        characters, this may be an indication that either a full license or the
+        font's description has been included in this field by mistake.
 
     """
     + DESCRIPTION_OF_EXPECTED_COPYRIGHT_STRING_FORMATTING,
     severity=10,  # max severity because licensing mistakes can cause legal problems.
-    proposal="https://github.com/fonttools/fontbakery/pull/2383",
+    proposal=[
+        "https://github.com/fonttools/fontbakery/pull/2383",
+        "legacy:check/155",
+    ],
 )
-def com_google_fonts_check_font_copyright(ttFont):
+def com_google_fonts_check_font_copyright(ttFont, font_metadata, config):
     """Copyright notices match canonical pattern in fonts"""
     import re
     from fontbakery.utils import get_name_entry_strings
 
-    for string in get_name_entry_strings(ttFont, NameID.COPYRIGHT_NOTICE):
+    copyrights = [
+        ("Name Table entry", string)
+        for string in get_name_entry_strings(ttFont, NameID.COPYRIGHT_NOTICE)
+    ]
+    if font_metadata:
+        copyrights.append(("METADATA.pb", font_metadata.copyright))
+
+    sources_of_copyrights = defaultdict(list)
+
+    for source, string in copyrights:
+        sources_of_copyrights[string].append(source)
         if not re.search(EXPECTED_COPYRIGHT_PATTERN, string.lower()):
             yield FAIL, Message(
                 "bad-notice-format",
-                f"Name Table entry: Copyright notices should match"
-                f" a pattern similar to:\n\n"
-                f'"Copyright 2019 The Familyname Project Authors (git url)"\n\n'
-                f'But instead we have got:\n\n"{string}"\n',
+                f"{source}: Copyright notices should match a pattern similar to:\n\n"
+                f' "Copyright 2020 The Familyname Project Authors (git url)"\n\n'
+                f'But instead we have got:\n\n"{string}"',
             )
 
-
-@disable
-@check(id="com.google.fonts/check/glyphs_file/font_copyright")
-def com_google_fonts_check_glyphs_file_font_copyright(glyphsFile):
-    """Copyright notices match canonical pattern in fonts"""
-    import re
-
-    string = glyphsFile.copyright.lower()
-    if not re.search(EXPECTED_COPYRIGHT_PATTERN, string):
-        yield FAIL, Message(
-            "bad-notice-format",
-            f"Copyright notices should match"
-            f' a pattern similar to: "Copyright 2019'
-            f' The Familyname Project Authors (git url)"\n'
-            f'But instead we have got:\n"{string}"',
-        )
-
-
-@check(
-    id="com.google.fonts/check/metadata/copyright_max_length",
-    conditions=["font_metadata"],
-    proposal="legacy:check/104",
-    rationale="""
-        We check that the copyright notice within the METADATA.pb file is
-        not too long; if it is more than 500 characters, this may be an
-        indiciation that either a full license or the font's description
-        has been included in this field by mistake.
-    """,
-)
-def com_google_fonts_check_metadata_copyright_max_length(font_metadata):
-    """METADATA.pb: Copyright notice shouldn't exceed 500 chars."""
-    if len(font_metadata.copyright) > 500:
-        yield FAIL, Message(
-            "max-length",
-            "METADATA.pb: Copyright notice exceeds"
-            " maximum allowed lengh of 500 characteres.",
-        )
-
-
-@check(
-    id="com.google.fonts/check/metadata/nameid/copyright",
-    conditions=["font_metadata"],
-    proposal="legacy:check/155",
-    rationale="""
-        This check verifies that the copyright field in METADATA.pb matches the
-        contents of the name table nameID 0 (Copyright).
-    """,
-)
-def com_google_fonts_check_metadata_nameid_copyright(ttFont, font_metadata):
-    """Copyright field for this font on METADATA.pb matches
-    all copyright notice entries on the name table ?"""
-    for nameRecord in ttFont["name"].names:
-        string = nameRecord.string.decode(nameRecord.getEncoding())
-        if (
-            nameRecord.nameID == NameID.COPYRIGHT_NOTICE
-            and string != font_metadata.copyright
-        ):
+        if len(string) > 500:
             yield FAIL, Message(
-                "mismatch",
-                f"Copyright field for this font on METADATA.pb"
-                f' ("{font_metadata.copyright}") differs from'
-                f" a copyright notice entry on the name table:"
+                "max-length",
+                f"{source}: The length of the following copyright"
+                f" notice ({len(string)}) exceeds 500 chars:"
                 f' "{string}"',
             )
 
-
-@check(
-    id="com.google.fonts/check/name/copyright_length",
-    rationale="""
-        This is an arbitrary max length for the copyright notice field of the name
-        table. We simply don't want such notices to be too long. Typically such notices
-        are actually much shorter than this with a length of roughly 70 or 80
-        characters.
-    """,
-    proposal="https://github.com/fonttools/fontbakery/issues/1603",
-)
-def com_google_fonts_check_name_copyright_length(ttFont):
-    """Length of copyright notice must not exceed 500 characters."""
-    from fontbakery.utils import get_name_entries
-
-    for notice in get_name_entries(ttFont, NameID.COPYRIGHT_NOTICE):
-        notice_str = notice.string.decode(notice.getEncoding())
-        if len(notice_str) > 500:
-            yield FAIL, Message(
-                "too-long",
-                f"The length of the following copyright notice"
-                f" ({len(notice_str)}) exceeds 500 chars:"
-                f' "{notice_str}"',
-            )
+    if len(sources_of_copyrights) > 1:
+        yield FAIL, Message(
+            "mismatch",
+            "Copyright notices differ between name table entries and METADATA.pb."
+            "The following copyright values were found:\n\n"
+            + show_inconsistencies(sources_of_copyrights, config),
+        )

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -14,7 +14,6 @@ PROFILE = {
             "com.google.fonts/check/metadata/consistent_axis_enumeration",
             "com.google.fonts/check/metadata/consistent_repo_urls",
             "com.google.fonts/check/metadata/copyright",
-            "com.google.fonts/check/metadata/copyright_max_length",
             "com.google.fonts/check/metadata/date_added",
             "com.google.fonts/check/metadata/designer_profiles",
             "com.google.fonts/check/metadata/designer_values",
@@ -35,7 +34,6 @@ PROFILE = {
             "com.google.fonts/check/metadata/match_weight_postscript",
             "com.google.fonts/check/metadata/menu_and_latin",
             "com.google.fonts/check/metadata/minisite_url",
-            "com.google.fonts/check/metadata/nameid/copyright",
             "com.google.fonts/check/metadata/nameid/family_and_full_names",
             # FIXME! The check below (metadata/nameid/font_name) looks
             #        suspiciously similar to the now deprecated
@@ -57,7 +55,6 @@ PROFILE = {
             "com.google.fonts/check/metadata/unique_weight_style_pairs",
             "com.google.fonts/check/metadata/unreachable_subsetting",
             "com.google.fonts/check/metadata/unsupported_subsets",
-            "com.google.fonts/check/metadata/valid_copyright",
             "com.google.fonts/check/metadata/valid_filename_values",
             "com.google.fonts/check/metadata/valid_full_name_values",
             "com.google.fonts/check/metadata/valid_nameid25",
@@ -133,7 +130,6 @@ PROFILE = {
             "com.google.fonts/check/meta/script_lang_tags",
             "com.google.fonts/check/missing_small_caps_glyphs",
             "com.google.fonts/check/name/ascii_only_entries",
-            "com.google.fonts/check/name/copyright_length",
             "com.google.fonts/check/name/description_max_length",
             "com.google.fonts/check/name/familyname_first_char",
             "com.google.fonts/check/name/mandatory_entries",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -2031,36 +2031,6 @@ def test_check_font_copyright():
     )
 
 
-def DISABLE_test_check_glyphs_file_font_copyright():
-    """Copyright notices match canonical pattern in fonts"""
-    check = CheckTester("com.google.fonts/check/glyphs_file/font_copyright")
-
-    glyphsFile = GLYPHSAPP_TEST_FILE("Comfortaa.glyphs")
-    # note: the check does not actually verify that the project name is correct.
-    #       It only focuses on the string format.
-
-    # Use an email instead of a git URL:
-    bad_string = (
-        "Copyright 2017 The Archivo Black Project Authors"
-        " (contact-us@fake-address.com)"
-    )
-    glyphsFile.copyright = bad_string
-    assert_results_contain(
-        check(glyphsFile),
-        FAIL,
-        "bad-notice-format",
-        "with a bad copyright notice string...",
-    )
-
-    # We change it into a good string (example extracted from Archivo Black):
-    good_string = (
-        "Copyright 2017 The Archivo Black Project Authors"
-        " (https://github.com/Omnibus-Type/ArchivoBlack)"
-    )
-    glyphsFile.copyright = good_string
-    assert_PASS(check(glyphsFile), "with a good coopyright string...")
-
-
 def test_check_metadata_reserved_font_name():
     """Copyright notice on METADATA.pb should not contain Reserved Font Name."""
     check = CheckTester("com.google.fonts/check/metadata/reserved_font_name")


### PR DESCRIPTION
## Description

`fontbakery.checks.googlefonts.copyright` is a good example of #4735 (many simple checks versus fewer larger checks).

Currently we have:

* A check to ensure the font name table copyright field has the right format
* A check to ensure the font name table copyright field is less than 500 characters
* A check to ensure the METADATA.pb copyright field has the right format
* A check to ensure the METADATA.pb copyright field is less than 500 characters
* A check to ensure the METADATA.pb copyright field and the name table copyright field are the same

This turns them into a single check

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

