### PR TITLE
Look for Italic only in style name, not whole file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[com.google.fonts/check/outline_direction]:** fixed an error where single-point contours would crash the check. (PR #4745)
 
 #### On the Google Fonts profile
+  - **[com.google.fonts/check/family/italics_have_roman_counterparts]:** Look for style name only after "-" in file name. (issue #1733)
   - Checks which validate the description files now also validate article files (issue #4730)
   - **[com.google.font/check/description/unsupported_elements]:** Also checks for wellformedness of HTML video tags. (issue #4730)
   - **[com.google.fonts/check/metadata/copyright_max_length], [com.google.fonts/check/metadata/nameid/copyright], [com.google.fonts/check/metadata/valid_copyright], [com.google.fonts/check/name/copyright_length]:** These checks have all been merged into [com.google.fonts/check/font_copyright]. (PR #4748 / issue #4735)

--- a/Lib/fontbakery/checks/googlefonts/family.py
+++ b/Lib/fontbakery/checks/googlefonts/family.py
@@ -55,7 +55,11 @@ def com_google_fonts_check_family_italics_have_roman_counterparts(fonts, config)
     """Ensure Italic styles have Roman counterparts."""
 
     filenames = [f.file for f in fonts]
-    italics = [f.file for f in fonts if "Italic" in f.file]
+    italics = [
+        f.file
+        for f in fonts
+        if "Italic" in f.file and f.file.find("-") < f.file.find("Italic")
+    ]
     missing_roman = []
     for italic in italics:
         if (


### PR DESCRIPTION
## Description

Check was looking for `Italic` in whole file name, but I'm shortly going to onboard a font called "ZainItalic-Regular" because there's (for now) only one Italic style as opposed to 6 Roman styles, so we break it out into its own family, so the check should focus on the style name only (after `-`).

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

