### PR TITLE
Support setting variations in update_shaping_tests input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.7 (2024-May-??)
+  - Support setting `input.variations` in input TOML for `update_shaping_tests`. (PR #4753)
+
 ### New checks
 #### Added to the Google Fonts profile
   - **EXPERIMENTAL - [com.google.fonts/check/metadata/date_added]:** Check that the date_added field is not empty or malformed. (issue #4729)

--- a/Lib/fontbakery/update_shaping_tests.py
+++ b/Lib/fontbakery/update_shaping_tests.py
@@ -79,7 +79,7 @@ def update_shaping_output(
         shaper = vhb.Vharfbuzz(font_path)
         font = TTFont(font_path)
         for text in shaping_input["input"]["text"]:
-            if "fvar" in font:
+            if "fvar" in font and "variations" not in shaping_input["input"]:
                 fvar: table__f_v_a_r = font["fvar"]  # type: ignore
                 for instance in fvar.instances:
                     run = shape_run(
@@ -114,6 +114,8 @@ def shape_run(
     if features := shaping_input.get("features"):
         parameters["features"] = features
     if variations:
+        parameters["variations"] = variations
+    elif variations := shaping_input.get("variations"):
         parameters["variations"] = variations
     buffer = shaper.shape(text, parameters)
 


### PR DESCRIPTION
If input.variations is explicitly set, it will be used instead of using instance coordinates from fvar table.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

