### PR TITLE
Clarify error message of [com.adobe.fonts/check/varfont/valid_default_instance_nameids]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Universal profile
   - **EXPERIMENTAL - [com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table (issue #3020)
 
+### Changes to existing checks
+#### On the OpenType profile
+  - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]** Clarify that the problem may actually be NameID 17, rather than the default instance. (PR #4761)
+
 
 ## 0.12.7 (2024-Jun-04)
   - Support setting `input.variations` in input TOML for `update_shaping_tests`. (PR #4753)

--- a/Lib/fontbakery/checks/opentype/fvar.py
+++ b/Lib/fontbakery/checks/opentype/fvar.py
@@ -465,11 +465,25 @@ def com_adobe_fonts_check_varfont_valid_default_instance_nameids(
             if postscript_nameid == 0xFFFF:
                 postscript_nameid = "0xFFFF"
 
-            if subfam_name != font_subfam_name:
+            if name17 and subfam_name != font_subfam_name:
                 yield FAIL, Message(
                     "invalid-default-instance-subfamily-name",
                     f"{subfam_name!r} instance has the same coordinates as the default"
-                    f" instance; its subfamily name should be {font_subfam_name!r}",
+                    f" instance; its subfamily name should be {font_subfam_name!r}.\n\n"
+                    f"Note: It is alternatively possible that Name ID 17 is incorrect,"
+                    f" and should be set to the default instance subfamily name, {subfam_name!r},"
+                    f" rather than '{name17!r}'. If the default instance is {subfam_name!r},"
+                    f" NameID 17 is probably the problem.",
+                )
+
+            if not name17 and subfam_name != font_subfam_name:
+                yield FAIL, Message(
+                    "invalid-default-instance-subfamily-name",
+                    f"{subfam_name!r} instance has the same coordinates as the default"
+                    f" instance; its subfamily name should be {font_subfam_name!r}.\n\n"
+                    f"Note: If the default instance really is meant to be called {subfam_name!r},"
+                    f" the problem may be that the font lacks NameID 17, which should"
+                    f" probably be present and set to {subfam_name!r}.",
                 )
 
             # Validate the postScriptNameID string only if

--- a/tests/checks/opentype/fvar_test.py
+++ b/tests/checks/opentype/fvar_test.py
@@ -525,10 +525,10 @@ def test_check_varfont_valid_default_instance_nameids():
     msg = assert_results_contain(
         check(ttFont_1), FAIL, "invalid-default-instance-subfamily-name"
     )
-    assert msg == (
+    assert (
         "'Instance #1' instance has the same coordinates as the default"
         " instance; its subfamily name should be 'Regular'"
-    )
+    ) in msg
     # Restore the original ID
     dflt_inst.subfamilyNameID = 258
 
@@ -538,10 +538,10 @@ def test_check_varfont_valid_default_instance_nameids():
     msg = assert_results_contain(
         check(ttFont_2), FAIL, "invalid-default-instance-subfamily-name"
     )
-    assert msg == (
+    assert (
         "'MutatorMathTest' instance has the same coordinates as the default"
         " instance; its subfamily name should be 'LightCondensed'"
-    )
+    ) in msg
     # Restore the original ID
     dflt_inst.subfamilyNameID = 258
 
@@ -553,10 +553,10 @@ def test_check_varfont_valid_default_instance_nameids():
     msg = assert_results_contain(
         check(ttFont_1), FAIL, "invalid-default-instance-postscript-name"
     )
-    assert msg == (
+    assert (
         "'Regular' instance has the same coordinates as the default instance;"
         " its postscript name should be 'Cabin-Regular', instead of 'None'."
-    )
+    ) in msg
 
     # The default instance of MutatorSans-VF has the correct postScriptNameID.
     # Change it to make the check fail.
@@ -565,11 +565,11 @@ def test_check_varfont_valid_default_instance_nameids():
     msg = assert_results_contain(
         check(ttFont_2), FAIL, "invalid-default-instance-postscript-name"
     )
-    assert msg == (
+    assert (
         "'LightCondensed' instance has the same coordinates as the default instance;"
         " its postscript name should be 'MutatorMathTest-LightCondensed',"
         " instead of 'MutatorMathTest-BoldCondensed'."
-    )
+    ) in msg
 
     # Confirm the check yields FAIL if the font doesn't have a required table
     del ttFont_1["name"]


### PR DESCRIPTION
## Description

`com.adobe.fonts/check/varfont/valid_default_instance_nameids` checks whether there is consistency between the default instance of a variable font and the font’s typographic style name, in either NameID 2 or NameID 17. 

This is important, but the current check isn’t very clear about an easy problem to fall into, so it’s hard to take action on / easy to ignore. 

## Example

To be specific, with an issue that recently occurred in practice on a font I helped build: it is easy in GlyphsApp to set up a variable font export wherein the Typographic Style Name (NameID 17) is set to "Regular" – even if the default location of that font is at, say, Hairline. The designer set up the font like this, which seems like an intuitive enough name, if you are making related but separate Roman and Italic variable fonts.

However, this results in an incorrectly NameID 17. This is a problem in macOS apps, for one, where this will result in the default instance being hidden from the style menu. In this case, the "Hairline" style was missing from the TextEdit style menu.

However, the existing fail/warn message only suggests renaming the _default instance_, which is confusing. Users are likely to see that message and think, "Why would I rename 'Hairline' to 'Regular'? My exports are set up with the intended style names."

I considered writing a totally new check to avoid this scenario, which would check to confirm that NameID 17 matches the default style. However, that would be redundant. This check does catch the problem scenario, but it simply doesn’t present the information in a way that is easy to understand and take action on.

## Proposed solution

The current message is like this:
> **FAIL** 'Hairline' instance has the same coordinates as the default instance; its subfamily name should be 'Regular'.

My proposed message adds a note:
> **FAIL** 'Hairline' instance has the same coordinates as the default instance; its subfamily name should be 'Regular'.                                                                                                                                                          
> 
> Note: It is alternatively possible that Name ID 17 is incorrect, and should be set to the default instance’s subfamily name, 'Hairline', rather than 'Regular'.

This note is only added if the font actually has NameID 17, and it doesn’t match the default instance. If the font lacks NameID 17, and the default instance doesn’t match NameID 2, the user may have a 'regular' default instance with a non-standard but valid name like "Book." In that case, they would see a message like this:
> **FAIL** 'Book' instance has the same coordinates as the default instance; its subfamily name should be 'Regular'.                                                                                                                                                          
> 
> Note: If the default instance really is supposed to be called 'Book', the problem may be that the font lacks NameID 17, which should probably be present and set to 'Book'.

I may be missing something, and the note I’ve added could probably be further improved. Either way, I’m happy to be given feedback!

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

