### PR TITLE
New check:  Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.8 (2024-Jun-??)
-  - ...
+### New checks
+#### Added to the Universal profile
+  - **EXPERIMENTAL - [com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table (issue #3020)
 
 
 ## 0.12.7 (2024-Jun-04)

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -19,6 +19,7 @@ PROFILE = {
             "com.google.fonts/check/fontbakery_version",
             "com.adobe.fonts/check/freetype_rasterizer",
             "com.google.fonts/check/gpos7",
+            "com.google.fonts/check/gsub/smallcaps_before_ligatures",
             "com.google.fonts/check/interpolation_issues",
             "com.google.fonts/check/legacy_accents",
             "com.google.fonts/check/linegaps",


### PR DESCRIPTION
* Added to the Universal profile
* **com.google.fonts/check/gsub/smallcaps_before_ligatures**

(issue #3020)