### PR TITLE
Ignore unreachable alt caron in OTF fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### New checks
 #### Added to the Universal profile
   - **EXPERIMENTAL - [com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table (issue #3020)
+  - [com.google.fonts/check/unreachable_glyphs]: ignore /caroncomb.alt and /uni030C.alt when checking OTF fonts, as these are often present as components for related TTF fonts
 
 
 ## 0.12.7 (2024-Jun-04)

--- a/Lib/fontbakery/checks/universal/glyphset.py
+++ b/Lib/fontbakery/checks/universal/glyphset.py
@@ -246,6 +246,15 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
             if base_glyph.isComposite() and glyph_name not in all_glyphs:
                 all_glyphs -= set(base_glyph.getComponentNames(ttFont["glyf"]))
 
+    # In OTF fonts, ignore glyphs that are commonly only present as componenents in TTF fonts
+    if "CFF " in ttFont:
+        glyphsToIgnoreInOTF = [
+            "uni030C.alt",
+            "caroncomb.alt",
+        ]
+        all_glyphs -= set(glyphsToIgnoreInOTF)
+
+
     if all_glyphs:
         yield WARN, Message(
             "unreachable-glyphs",

--- a/Lib/fontbakery/checks/universal/glyphset.py
+++ b/Lib/fontbakery/checks/universal/glyphset.py
@@ -254,7 +254,6 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
         ]
         all_glyphs -= set(glyphsToIgnoreInOTF)
 
-
     if all_glyphs:
         yield WARN, Message(
             "unreachable-glyphs",


### PR DESCRIPTION
## Description

In making Latin script fonts, it is common to create the glyph /caroncomb.alt, which is then used as a component in glyphs /lcaron, /dcaron, /tcaron, and /Lcaron. ([More info here.](https://www.typotheque.com/articles/lcaron))

This /caroncomb.alt is only used as a component, and doesn't have a Unicode value, as far as I am aware. So, it is unreachable by itself. Thankfully, it is ignored by the check `com.google.fonts/check/unreachable_glyphs` in TTF fonts, as there, it is possible to ignore glyphs used as components, thanks to https://github.com/fonttools/fontbakery/issues/4378.

However, it is not ignore in OTF fonts, where there isn’t the same system of components. So, if users have correctly set up /caroncomb.alt, they get a WARN for this glyphs as being unreachable, when checking OTF fonts.

This PR simply removes glyph names /caroncomb.alt and /uni030C.alt from the check, when the font being checked is an OTF. I’ve tried to write the ignore list to be extendable, if there are other common cases that arise. 

It is very possible that there is a better way to check whether a font is an OTF, or that there is some better way to detect this kind of case in an OTF. Or, perhaps we want to enforce some kind of removal of this glyph in OTFs, though it’s hard to imagine that such a post-build process would be worth the added complexity. 

Anyway, I’m very happy to have a discussion or receive feedback, here! Thanks for reviewing this PR.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

