### PR TITLE
Update reserved_font_name_exceptions.txt - Rammetto One

### DIFF
--- a/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/reserved_font_name_exceptions.txt
@@ -24,6 +24,7 @@ Lateef
 Mingzat
 Narnoor
 Nuosu SIL
+Rammetto One
 Scheherazade New
 Tai Heritage Pro
 Datalegreya


### PR DESCRIPTION
## Description
Added Rammetto to the list. All the Vernon Adams fonts can keep the RFN

@davelab6

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

