### PR TITLE
unreachable_glyphs: JSTF table, Extender glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **EXPERIMENTAL - [com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table (issue #3020)
 
 ### Changes to existing checks
+#### On the Universal profile
+  - **[com.google.fonts/check/unreachable_glyphs]:** Glyphs identified in the Extender Glyph Table within JSTF table, such as kashidas, are not included in the check output. (issue #4773)
+
 #### On the OpenType profile
   - **[com.adobe.fonts/check/varfont/valid_default_instance_nameids]** Clarify that the problem may actually be NameID 17, rather than the default instance. (PR #4761)
 

--- a/Lib/fontbakery/checks/universal/glyphset.py
+++ b/Lib/fontbakery/checks/universal/glyphset.py
@@ -170,6 +170,14 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
     all_glyphs.discard(".null")
     all_glyphs.discard(".notdef")
 
+    # Glyphs identified in the Extender Glyph Table within JSTF table,
+    # such as kashidas, are not included in the check output:
+    # https://github.com/fonttools/fontbakery/issues/4773
+    if "JSTF" in ttFont:
+        for subtable in ttFont["JSTF"].table.iterSubTables():
+            for extender_glyph in subtable.value.JstfScript.ExtenderGlyph.ExtenderGlyph:
+                all_glyphs.discard(extender_glyph)
+
     if "MATH" in ttFont:
         glyphinfo = ttFont["MATH"].table.MathGlyphInfo
         mathvariants = ttFont["MATH"].table.MathVariants


### PR DESCRIPTION
Glyphs identified in the Extender Glyph Table within JSTF table, such as kashidas, are not included in the check output.

* **com.google.fonts/check/unreachable_glyphs**
* On the Universal profile

(issue #4773)