### PR TITLE
New check `com,google.fonts/check/metadata/single_cjk_subset` added to `Google Fonts` profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## Upcoming release: 0.12.8 (2024-Jun-??)
+## Upcoming release: 0.12.8 (2024-Jul-??)
 ### New checks
 #### Added to the OpenType profile
   - **EXPERIMENTAL - [com.adobe.fonts/check/cff_ascii_strings]:** Checks if all strings in a font's CFF table top dict fit in the range of ASCII values (issue #4619)
+
+#### Added to the Google Fonts profile
+- **EXPERIMENTAL - [com.google.fonts/check/metadata/single_cjk_subset]:** Check METADATA.pb file only contains a single CJK subset since the Google Fonts backend doesn't support multiple CJK subsets. (issue #4779)
 
 #### Added to the Universal profile
   - **EXPERIMENTAL - [com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table (issue #3020)

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -370,6 +370,37 @@ def com_google_fonts_check_metadata_includes_production_subsets(
 
 
 @check(
+    id="com.google.fonts/check/metadata/single_cjk_subset",
+    conditions=["family_metadata"],
+    rationale="""
+        Check METADATA.pb file only contains a single CJK subset since the Google Fonts
+        backend doesn't support multiple CJK subsets.
+    """,
+    proposal="https://github.com/fonttools/fontbakery/issues/4779",
+    experimental="Since 2024/Jul/02",
+)
+def com_google_fonts_check_metadata_single_cjk_subset(family_metadata):
+    """Check METADATA.pb file only contains a single CJK subset."""
+    cjk_subsets = frozenset(
+        [
+            "chinese-hongkong",
+            "chinese-simplified",
+            "chinese-traditional",
+            "korean",
+            "japanese",
+        ]
+    )
+    cjk_subset_in_font = set(family_metadata.subsets) & cjk_subsets
+
+    if len(cjk_subset_in_font) > 1:
+        yield FATAL, Message(
+            "multiple-cjk-subsets",
+            "METADATA.pb file contains more than one CJK subset. Please choose "
+            f"only one from {', '.join(cjk_subsets)}.",
+        )
+
+
+@check(
     id="com.google.fonts/check/metadata/copyright",
     conditions=["family_metadata"],
     proposal="legacy:check/088",

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -27,6 +27,7 @@ PROFILE = {
             "com.google.fonts/check/metadata/has_regular",
             "com.google.fonts/check/metadata/has_tags",
             "com.google.fonts/check/metadata/includes_production_subsets",
+            "com.google.fonts/check/metadata/single_cjk_subset",
             "com.google.fonts/check/metadata/license",
             "com.google.fonts/check/metadata/match_filename_postscript",
             "com.google.fonts/check/metadata/match_fullname_postscript",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -1551,6 +1551,31 @@ def test_check_metadata_includes_production_subsets(requests_mock):
     )
 
 
+def test_check_metadata_single_cjk_subset():
+    """Check METADATA.pb file only contains a single CJK subset"""
+    check = CheckTester(
+        "com.google.fonts/check/metadata/single_cjk_subset",
+    )
+    font = TEST_FILE("familysans/FamilySans-Regular.ttf")
+    md = Font(font).family_metadata
+
+    # Test should pass since there isn't a CJK subset
+    assert_PASS(check(MockFont(file=font, family_metadata=md)))
+
+    # Let's append a single cjk subset
+    md.subsets.append("korean")
+    assert_PASS(check(MockFont(file=font, family_metadata=md)))
+
+    # Let's add another to raise a FATAL
+    md.subsets.append("japanese")
+    assert_results_contain(
+        check(MockFont(file=font, family_metadata=md)),
+        FATAL,
+        "multiple-cjk-subsets",
+        "METADATA.pb has multiple cjk subsets...",
+    )
+
+
 def test_check_metadata_copyright():
     """METADATA.pb: Copyright notice is the same in all fonts?"""
     check = CheckTester("com.google.fonts/check/metadata/copyright")


### PR DESCRIPTION
Fixes #4779

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

