### PR TITLE
smallcaps_before_ligatures is not relevant to fonts without smcp feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.9 (2024-Jul-??)
-  - ...
+### Noteworthy code-changes
+  - **EXPERIMENTAL - [com.google.fonts/check/gsub/smallcaps_before_ligatures]:** This check is not relevant to fonts without the 'smcp' feature. Do not fail on fonts without smallcaps.
 
 
 ## 0.12.8 (2024-Jul-05)

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -1226,7 +1226,7 @@ def com_google_fonts_check_gsub_smallcaps_before_ligatures(ttFont):
     Ensure 'smcp' (small caps) lookups are defined before ligature lookups in the 'GSUB' table.
     """
     if "GSUB" not in ttFont:
-        return FAIL, Message(
+        return SKIP, Message(
             "missing-gsub-table", "Font does not contain a GSUB table."
         )
 

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -1248,7 +1248,7 @@ def com_google_fonts_check_gsub_smallcaps_before_ligatures(ttFont):
     ]
 
     if not smcp_indices or not liga_indices:
-        return FAIL, Message(
+        return SKIP, Message(
             "missing-lookups", "'smcp' or 'liga' lookups not found in GSUB table."
         )
 

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -1462,10 +1462,10 @@ def test_check_gsub_smallcaps_before_ligatures():
 
     # Test 'smcp' lookup missing
     ttFont["GSUB"].table.FeatureList.FeatureRecord = [liga_record]
-    msg = assert_results_contain(check(ttFont), FAIL, "missing-lookups")
+    msg = assert_results_contain(check(ttFont), SKIP, "missing-lookups")
     assert "'smcp' or 'liga' lookups not found in GSUB table." in msg
 
     # Test 'liga' lookup missing
     ttFont["GSUB"].table.FeatureList.FeatureRecord = [smcp_record]
-    msg = assert_results_contain(check(ttFont), FAIL, "missing-lookups")
+    msg = assert_results_contain(check(ttFont), SKIP, "missing-lookups")
     assert "'smcp' or 'liga' lookups not found in GSUB table." in msg

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -1438,7 +1438,7 @@ def test_check_gsub_smallcaps_before_ligatures():
 
     # Test GSUB table is missing
     del ttFont["GSUB"]
-    msg = assert_results_contain(check(ttFont), FAIL, "missing-gsub-table")
+    msg = assert_results_contain(check(ttFont), SKIP, "missing-gsub-table")
     assert "Font does not contain a GSUB table." in msg
 
     # Restore GSUB table for further tests


### PR DESCRIPTION
## Description
Relates to issue #3020

The new smallcaps_before_ligatures check fails for fonts without `smcp`. As noted in two seperate comments to #3020, this is counter to expectations, as the issue the check intends to detect is clearly only relevant to fonts using both the `smcp` and `liga` features.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

