### PR TITLE
Check typoAscender exceeds /Agrave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## 0.12.9 (2024-Jul-17)
 ### New checks
+#### Added to the Universal profile
+  - **EXPERIMENTAL - [com.arrowtype.fonts/check/typoascender_exceeds_Agrave]:** Check that the typoAscender exceeds the yMax of the /Agrave (issue #3170)
+
 #### Added to the UFO profile
   -  **EXPERIMENTAL - [com.google.fonts/check/consistent_curve_type]:**: checks that a consistent curve type is used across the font sources as well as within glyphs. (PR #4795)
 

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -37,6 +37,7 @@ PROFILE = {
             "com.google.fonts/check/tabular_kerning",
             "com.google.fonts/check/transformed_components",
             "com.google.fonts/check/ttx_roundtrip",
+            "com.arrowtype.fonts/check/typoascender_exceeds_Agrave",
             "com.google.fonts/check/unique_glyphnames",
             "com.google.fonts/check/unreachable_glyphs",
             "com.google.fonts/check/unwanted_tables",


### PR DESCRIPTION
## Description

Adds a check that ensures the typoAscender is taller than the /Agrave, as proposed in https://github.com/fonttools/fontbakery/issues/3170.

Okay, the check seems to be working well! I’ve tested it on:
- An OTF font with an /Agrave that exceeds the typoAscender. It fails and provides a rationale.
- An OTF font with an /Agrave that doesn’t exceed the typoAscender. It passes.
- TTF fonts that do and do not fail.
- OTF and TTF fonts that don’t include an /Agrave. It skips this successfully, and provides the reason if the `--verbose` arg is passed.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

