### PR TITLE
Add consistent curve type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal profile
   - **[com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Skip check if font lacks GSUB table or font is missing either liga or smcp features. (PR #4787)
 
+### New checks
+  -  **EXPERIMENTAL - [com.google.fonts/check/consistent_curve_type]:**: checks that a consistent curve type is used across the font sources as well as within glyphs
+
 
 ## 0.12.8 (2024-Jul-05)
 ### Noteworthy code-changes


### PR DESCRIPTION
## Description

Adds a new check that flags any glyphs with a mix of quadratic & cubic curves, and additionally checks if the font contains cubic glyphs and quadratic glyphs

I'm not sure if this is in the right place in the codebase and if we want to include it in any profiles by default. Moreso this PR is to help make checks from private repositories public where it makes sense to do so

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

