### PR TITLE
Fix ERROR on `check/unreachable_glyphs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal profile
   - **[com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Skip check if font lacks GSUB table or font is missing either liga or smcp features. (PR #4787)
 
+#### On the Shaping profile
+  - **[com.google.fonts/check/unreachable_glyphs]:** Fix ERROR by being sure that we have a LayerList before attempting to access it. (issue #4786)
+
 
 ## 0.12.8 (2024-Jul-05)
 ### Noteworthy code-changes

--- a/Lib/fontbakery/checks/universal/glyphset.py
+++ b/Lib/fontbakery/checks/universal/glyphset.py
@@ -237,9 +237,10 @@ def com_google_fonts_check_unreachable_glyphs(ttFont, config):
                 if hasattr(paint_record.Paint, "Glyph"):
                     all_glyphs.discard(paint_record.Paint.Glyph)
 
-            for paint in ttFont["COLR"].table.LayerList.Paint:
-                if hasattr(paint, "Glyph"):
-                    all_glyphs.discard(paint.Glyph)
+            if ttFont["COLR"].table.LayerList:
+                for paint in ttFont["COLR"].table.LayerList.Paint:
+                    if hasattr(paint, "Glyph"):
+                        all_glyphs.discard(paint.Glyph)
 
     if "GSUB" in ttFont and ttFont["GSUB"].table.LookupList:
         lookups = ttFont["GSUB"].table.LookupList.Lookup


### PR DESCRIPTION
Be sure we have a LayerList before attempting to access it.

* **com.google.fonts/check/unreachable_glyphs**
* On Shaping profile.

(issue #4786)