### PR TITLE
Consistent curve type check tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.10 (2024-Jul-??)
-  - ...
-
+### Changes to existing checks
+#### On the UFO profile
+  - **EXPERIMENTAL - [com.daltonmaag/check/consistent_curve_type]:**: remove usage of `ufoLib2` APIs
 
 ## 0.12.9 (2024-Jul-17)
 ### New checks
@@ -11,7 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
   - **EXPERIMENTAL - [com.arrowtype.fonts/check/typoascender_exceeds_Agrave]:** Check that the typoAscender exceeds the yMax of the /Agrave (issue #3170)
 
 #### Added to the UFO profile
-  -  **EXPERIMENTAL - [com.google.fonts/check/consistent_curve_type]:**: checks that a consistent curve type is used across the font sources as well as within glyphs. (PR #4795)
+  - **EXPERIMENTAL - [com.daltonmaag/check/consistent_curve_type]:**: checks that a consistent curve type is used across the font sources as well as within glyphs. (PR #4795)
 
 ### Changes to existing checks
 #### On the Universal profile

--- a/Lib/fontbakery/checks/ufo.py
+++ b/Lib/fontbakery/checks/ufo.py
@@ -373,7 +373,7 @@ def check_consistent_curve_type(config, ufo: Ufo):
     for layer in ufo.ufo_font.layers:  # type: ignore
         for glyph in layer:
             point_types = set(
-                point.type for contour in glyph.contours for point in contour.points
+                point.segmentType for contour in glyph for point in contour
             )
             if "curve" in point_types and "qcurve" in point_types:
                 mixed_glyphs.append(glyph.name)
@@ -387,7 +387,7 @@ def check_consistent_curve_type(config, ufo: Ufo):
             WARN,
             Message(
                 "mixed-glyphs",
-                f"{ufo.file_displayname} contains glyphs with mixed curves:\n\n"
+                f"UFO contains glyphs with mixed curves:\n\n"
                 f"{utils.bullet_list(config, mixed_glyphs)}\n",
             ),
         )
@@ -396,7 +396,7 @@ def check_consistent_curve_type(config, ufo: Ufo):
             WARN,
             Message(
                 "both-cubic-and-quadratic",
-                f"{ufo.file_displayname} contains a mix of cubic-curve glyphs"
+                f"UFO contains a mix of cubic-curve glyphs"
                 " and quadratic-curve glyphs\n\n"
                 "Cubics:\n\n"
                 f"{utils.bullet_list(config, cubic_glyphs)}\n\n"


### PR DESCRIPTION
## Description
Relates to feedback on #4797

Use `defcon` APIs, not `ufoLib2`, since this is what Fontbakery expects

Add test

Note: using `ufo.file_displayname` caused an exception during tests as `Ufo.file` is not mocked

Fixed up the previous changelog entry as you changed the check ID in code, but not the changelog

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

