### PR TITLE
New UFO source check: no open corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ## Upcoming release: 0.12.10 (2024-Jul-??)
-  - ...
+### New checks
+  - **EXPERIMENTAL - [com.daltonmaag/check/no_open_corners]:** checks that sources don't contain open corners, intended for use in font projects with a roundness axis (PR #4808)
 
 
 ## 0.12.9 (2024-Jul-17)

--- a/Lib/fontbakery/checks/ufo.py
+++ b/Lib/fontbakery/checks/ufo.py
@@ -418,6 +418,7 @@ def check_consistent_curve_type(config, ufo: Ufo):
         axis.
     """,
     conditions=["ufo_font"],
+    proposal="https://github.com/fonttools/fontbakery/pull/4808",
 )
 def check_no_open_corners(config, ufo):
     """Check the sources have no corners"""

--- a/Lib/fontbakery/checks/ufo.py
+++ b/Lib/fontbakery/checks/ufo.py
@@ -425,7 +425,6 @@ def check_no_open_corners(config, ufo):
     from fontTools.pens.basePen import NullPen
 
     font = ufo.ufo_font
-    default_layer_name = font.layers.defaultLayer.name
     for layer in font.layers:
         offending_glyphs = []
         for glyph in layer:
@@ -437,9 +436,9 @@ def check_no_open_corners(config, ufo):
 
         if offending_glyphs:
             location_str = (
-                ufo.file_displayname
-                if layer.name == default_layer_name
-                else f"{ufo.file_displayname} (layer {layer.name})"
+                "Default layer"
+                if layer.name == font.layers.defaultLayer.name
+                else layer.name
             )
             yield (
                 FAIL,

--- a/data/test/test.ufo/glyphs/contents.plist
+++ b/data/test/test.ufo/glyphs/contents.plist
@@ -8,5 +8,7 @@
 	<string>B_.glif</string>
 	<key>C</key>
 	<string>C_.glif</string>
+  <key>square</key>
+  <string>square.glif</string>
 </dict>
 </plist>

--- a/data/test/test.ufo/glyphs/square.glif
+++ b/data/test/test.ufo/glyphs/square.glif
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="square" format="2">
+  <advance width="600"/>
+  <outline>
+    <contour>
+      <!-- Intentional open corners for test_check_no_open_corners -->
+      <point x="547" y="128" type="line"/>
+      <point x="495" y="100" type="line"/>
+      <point x="482" y="454" type="line"/>
+      <point x="530" y="423" type="line"/>
+      <point x="110" y="417" type="line"/>
+      <point x="156" y="460" type="line"/>
+      <point x="163" y="100" type="line"/>
+      <point x="111" y="119" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/data/test/test.ufo/lib.plist
+++ b/data/test/test.ufo/lib.plist
@@ -7,6 +7,7 @@
 		<string>A</string>
 		<string>B</string>
 		<string>C</string>
+    <string>square</string>
 	</array>
 </dict>
 </plist>

--- a/tests/checks/ufo_sources_test.py
+++ b/tests/checks/ufo_sources_test.py
@@ -201,3 +201,17 @@ languagesystem latn dflt;
 feature liga { sub f i by f_i; } liga;"""
 
     assert_PASS(check(ufo))
+
+
+def test_check_no_open_corners() -> None:
+    """Ensure the check identifies open corners correctly"""
+    check = CheckTester("com.daltonmaag/check/no_open_corners")
+
+    ufo = defcon.Font(TEST_FILE("test.ufo"))
+
+    assert_results_contain(check(ufo), FAIL, "open-corners-found")
+
+    # Remove glyph with open corners
+    del ufo["square"]
+
+    assert_PASS(check(ufo))


### PR DESCRIPTION
## Description

In a similar vein to a couple of my previous check-related PRs, this is another check that was developed for a private project, but has no compelling reason to be kept closed source

As the name implies, the check looks to ensure the sources don't contain any open corners, as these will cause issues for fonts with a roundness (ROND) axis. We'd expect this check to be opt-in as a result as it's rather niche

For the test data, I piggybacked on an existing `test.ufo` to be able to more easily add in a `.glif` file. If desired, I can inline the glyph creation into the test code. As far as I've seen testing locally, adding this glyph to the UFO doesn't impact any other test results

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

