### PR TITLE
com_google_fonts_check_gsub_smallcaps_before_ligatures: check lig indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ A more detailed list of changes is available in the corresponding milestones for
   - The **Shaping** and **Outline** profile were also removed and their checks migrated to the **Google Fonts** profile. As gfonts was already including those, and no other profile did so, there's no need to add experimental flags to these ones. (issue #4801)
 
 ### Changes to existing checks
+#### Previously on the UFO profile
   - **EXPERIMENTAL - [com.daltonmaag/check/consistent_curve_type]:**: remove usage of `ufoLib2` APIs. (PR #4802)
+
+#### On the Universal profile
+  - **[com.google.fonts/check/gsub/smallcaps_before_ligatures]:** Check lookup indexes instead of feature indexes. (PR #4813)
 
 ### New checks
 #### Added to the Universal profile

--- a/Lib/fontbakery/checks/universal/__init__.py
+++ b/Lib/fontbakery/checks/universal/__init__.py
@@ -1231,14 +1231,16 @@ def com_google_fonts_check_gsub_smallcaps_before_ligatures(ttFont):
     gsub_table = ttFont["GSUB"].table
 
     smcp_indices = [
-        idx
-        for idx, feature in enumerate(gsub_table.FeatureList.FeatureRecord)
+        index
+        for feature in gsub_table.FeatureList.FeatureRecord
         if feature.FeatureTag == "smcp"
+        for index in feature.Feature.LookupListIndex
     ]
     liga_indices = [
-        idx
-        for idx, feature in enumerate(gsub_table.FeatureList.FeatureRecord)
+        index
+        for feature in gsub_table.FeatureList.FeatureRecord
         if feature.FeatureTag == "liga"
+        for index in feature.Feature.LookupListIndex
     ]
 
     if not smcp_indices or not liga_indices:

--- a/tests/checks/universal_test.py
+++ b/tests/checks/universal_test.py
@@ -1445,5 +1445,6 @@ def test_check_gsub_smallcaps_before_ligatures():
     assert_PASS(check(ttFont))
 
     # Test 'liga' lookup before 'smcp' lookup
-    ttFont["GSUB"].table.FeatureList.FeatureRecord = [liga_record, smcp_record]
+    smcp_feature.LookupListIndex = [1]
+    liga_feature.LookupListIndex = [0]
     assert_results_contain(check(ttFont), FAIL, "feature-ordering")


### PR DESCRIPTION
## Description

Current implementation is checking feature index which is incorrect. It should be lookup index instead.

This check currently fails for Merriweather but if I inspect the font with Crowbar, we can see it's fine.

 
<img width="1440" alt="Screenshot 2024-08-09 at 10 21 17" src="https://github.com/user-attachments/assets/0b19ab84-cb03-4716-b3b1-5902f1fdcd54">

The liga lookup lookup has an index of 73 so it isn't getting triggered because smcp has 71.

I still fear this check is too simple. It breaks when a font has multiple scripts say Latin and Arabic and the Arabic's liga lookup indexes are less than the Latin's liga and smcp indexes


## Checklist
- [X] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

