### PR TITLE
New check: consistent kerning groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-## Upcoming release: 0.12.11 (2024-Aug-??)
-  - ...
-
-
-## 0.12.10 (2024-Aug-09)
+##  Upcoming release: 0.12.10 (2024-Aug-??)
 ### Noteworthy code changes
   - The **UFO** profile was removed and its checks were migrated to the **Universal** profile. For that reason, all of them received a temporary "experimental" flag (issue #4801)
   - The **Shaping** and **Outline** profile were also removed and their checks migrated to the **Google Fonts** profile. As gfonts was already including those, and no other profile did so, there's no need to add experimental flags to these ones. (issue #4801)
@@ -21,6 +17,7 @@ A more detailed list of changes is available in the corresponding milestones for
 #### Added to the Universal profile
   - **EXPERIMENTAL - [com.daltonmaag/check/consistent_curve_type]:**: checks that a consistent curve type is used across the font sources as well as within glyphs. (PR #4795)
   - **EXPERIMENTAL - [com.daltonmaag/check/no_open_corners]:** checks that sources don't contain open corners, intended for use in font projects with a roundness axis. (PR #4808)
+  - **EXPERIMENTAL - [com.daltonmaag/check/designspace_has_consistent_groups]:** checks that all designspace sources have the same kerning groups. (PR #4814)
   - And all other pre-existing UFO checks as well.
 
 

--- a/Lib/fontbakery/checks/ufo.py
+++ b/Lib/fontbakery/checks/ufo.py
@@ -459,3 +459,30 @@ def check_no_open_corners(config, ufo):
                     f"{utils.bullet_list(config, offending_glyphs)}\n",
                 ),
             )
+
+
+@check(
+    id="com.daltonmaag/check/designspace_has_consistent_groups",
+    rationale="""
+        Often designers will want kerning groups to be consistent across their
+        whole Designspace, so this check helps flag if this isn't the case.
+    """,
+    proposal="https://github.com/fonttools/fontbakery/pull/4814",
+    experimental="Since 2024/Aug/12",
+)
+def check_designspace_has_consistent_groups(config, designSpace):
+    """Confirms that all sources have the same kerning groups per Designspace."""
+
+    default_source = designSpace.findDefault()
+    reference = default_source.font.groups
+    for source in designSpace.sources:
+        if source is default_source:
+            continue
+        if source.font.groups != reference:
+            yield (
+                WARN,
+                Message(
+                    "mismatched-kerning-groups",
+                    f"{source.filename} does not have the same kerning groups as default source.",
+                ),
+            )

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -18,6 +18,7 @@ PROFILE = {
             "com.daltonmaag/check/ufo_required_fields",
             "com.daltonmaag/check/ufo_recommended_fields",
             "com.daltonmaag/check/ufo_unnecessary_fields",
+            "com.daltonmaag/check/designspace_has_consistent_groups",
         ],
         "Universal Profile Checks": [
             "com.google.fonts/check/alt_caron",

--- a/data/test/mismatched_groups/Stupid Font Bold.ufo/fontinfo.plist
+++ b/data/test/mismatched_groups/Stupid Font Bold.ufo/fontinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Bold.ufo/glyphs/contents.plist
+++ b/data/test/mismatched_groups/Stupid Font Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Bold.ufo/groups.plist
+++ b/data/test/mismatched_groups/Stupid Font Bold.ufo/groups.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+    <key>a</key>
+    <array/>
+    <key>c</key>
+    <array/>
+  </dict>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Bold.ufo/layercontents.plist
+++ b/data/test/mismatched_groups/Stupid Font Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Bold.ufo/lib.plist
+++ b/data/test/mismatched_groups/Stupid Font Bold.ufo/lib.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Bold.ufo/metainfo.plist
+++ b/data/test/mismatched_groups/Stupid Font Bold.ufo/metainfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Regular.ufo/fontinfo.plist
+++ b/data/test/mismatched_groups/Stupid Font Regular.ufo/fontinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Regular.ufo/glyphs/contents.plist
+++ b/data/test/mismatched_groups/Stupid Font Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Regular.ufo/groups.plist
+++ b/data/test/mismatched_groups/Stupid Font Regular.ufo/groups.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+    <key>a</key>
+    <array/>
+    <key>b</key>
+    <array/>
+  </dict>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Regular.ufo/layercontents.plist
+++ b/data/test/mismatched_groups/Stupid Font Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Regular.ufo/lib.plist
+++ b/data/test/mismatched_groups/Stupid Font Regular.ufo/lib.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font Regular.ufo/metainfo.plist
+++ b/data/test/mismatched_groups/Stupid Font Regular.ufo/metainfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/data/test/mismatched_groups/Stupid Font.designspace
+++ b/data/test/mismatched_groups/Stupid Font.designspace
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="weight" minimum="1" maximum="1000" default="400"/>
+  </axes>
+  <sources>
+    <source filename="Stupid Font Bold.ufo" stylename="Regular">
+      <location>
+        <dimension name="weight" xvalue="700"/>
+      </location>
+    </source>
+    <source filename="Stupid Font Regular.ufo" stylename="Regular">
+      <location>
+        <dimension name="weight" xvalue="400"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/tests/checks/ufo_sources_test.py
+++ b/tests/checks/ufo_sources_test.py
@@ -253,3 +253,12 @@ def test_check_no_open_corners() -> None:
     del ufo["square"]
 
     assert_PASS(check(ufo))
+
+
+def test_check_designspace_has_consistent_groups(tmpdir) -> None:
+    """Ensure the check identifies mismatched groups correctly"""
+    check = CheckTester("com.daltonmaag/check/designspace_has_consistent_groups")
+
+    designspace_path = TEST_FILE("mismatched_groups/Stupid Font.designspace")
+
+    assert_results_contain(check(designspace_path), WARN, "mismatched-kerning-groups")


### PR DESCRIPTION
## Description

The last of my trilogy of new checks!

Checks kerning groups are consistent across all sources in a designspace. This is usually a desirable and just a mistake if a source falls out of sync with the rest. Added to the universal profile as I suspect most people would want this

Also @felipesanches we've added you as a collaborator (or whatever the proper term is) to our fork so you can (hopefully, if we've done it right) force-push over this PR if you want, save you the hassle of creating another :)

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

