### PR TITLE
com.google.fonts/check/metadata/has_tags: removed check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **EXPERIMENTAL - [com.daltonmaag/check/designspace_has_consistent_groups]:** checks that all designspace sources have the same kerning groups. (PR #4814)
   - And all other pre-existing UFO checks as well.
 
+### Removed checks
+  - **[com.google.fonts/check/metadata/has_tags]**: Check removed because a tool in the google/fonts repository will do the checking instead.
+
 
 ## 0.12.9 (2024-Jul-17)
 ### New checks

--- a/Lib/fontbakery/checks/googlefonts/conditions.py
+++ b/Lib/fontbakery/checks/googlefonts/conditions.py
@@ -1,5 +1,3 @@
-import csv
-from io import StringIO
 import os
 import re
 import yaml
@@ -16,19 +14,6 @@ from fontbakery.constants import (
 )
 from fontbakery.utils import exit_with_install_instructions
 
-
-GF_TAGS_SHEET_URL = (
-    "https://docs.google.com/spreadsheets/d/e/"
-    "2PACX-1vQVM--FKzKTWL-8w0l5AE1e087uU_OaQNHR3_kkxxymoZV5XUnHzv9TJIdy7vcd0Saf4m8CMTMFqGcg/"
-    "pub?gid=1193923458&single=true&output=csv"
-)
-
-# Submissions from designers via form https://forms.gle/jcp3nDv63LaV1rxH6
-GF_TAGS_SHEET_URL2 = (
-    "https://docs.google.com/spreadsheets/d/e/"
-    "2PACX-1vQVM--FKzKTWL-8w0l5AE1e087uU_OaQNHR3_kkxxymoZV5XUnHzv9TJIdy7vcd0Saf4m8CMTMFqGcg/"
-    "pub?gid=378442772&single=true&output=csv"
-)
 
 # @condition
 # def glyphsFile(glyphs_file):
@@ -497,24 +482,3 @@ def expected_font_names(ttFont, ttFonts):
         build_fvar_instances(font_cp)
         build_stat(font_cp, siblings)
     return font_cp
-
-
-_tags_cache = []
-
-
-def gf_tags():
-    import requests
-
-    global _tags_cache  # pylint:disable=W0603,W0602
-    if _tags_cache:
-        return _tags_cache
-
-    for url in (GF_TAGS_SHEET_URL, GF_TAGS_SHEET_URL2):
-        req = requests.get(url, timeout=10)
-        data = list(csv.reader(StringIO(req.text)))
-        # drop the first two columns on sheet2 since they contain
-        # the author and form submission date
-        if url == GF_TAGS_SHEET_URL2:
-            data = [i[2:] for i in data]
-        _tags_cache.extend(data)
-    return _tags_cache

--- a/Lib/fontbakery/checks/googlefonts/metadata.py
+++ b/Lib/fontbakery/checks/googlefonts/metadata.py
@@ -1356,26 +1356,6 @@ def com_google_fonts_check_metadata_empty_designer(family_metadata):
 
 
 @check(
-    id="com.google.fonts/check/metadata/has_tags",
-    conditions=["network"],
-    rationale="""
-        Any font published on Google Fonts must be listed in the tags spreadsheet.
-
-        https://forms.gle/jcp3nDv63LaV1rxH6
-    """,
-    proposal="https://github.com/fonttools/fontbakery/issues/4465",
-)
-def com_google_fonts_check_metadata_has_tags(family_metadata):
-    """The font has tags in the GF Tags spreadsheet"""
-    from fontbakery.checks.googlefonts.conditions import gf_tags
-
-    tags = gf_tags()
-    tagged_families = set(row[0] for row in tags[6:])
-    if family_metadata.name not in tagged_families:
-        yield FATAL, Message("no-tags", "Family does not appear in tag spreadsheet.")
-
-
-@check(
     id="com.google.fonts/check/metadata/escaped_strings",
     rationale="""
         In some cases we've seen designer names and other fields with escaped strings

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -25,7 +25,6 @@ PROFILE = {
             "com.google.fonts/check/metadata/gf_axisregistry_bounds",
             "com.google.fonts/check/metadata/gf_axisregistry_valid_tags",
             "com.google.fonts/check/metadata/has_regular",
-            "com.google.fonts/check/metadata/has_tags",
             "com.google.fonts/check/metadata/includes_production_subsets",
             "com.google.fonts/check/metadata/single_cjk_subset",
             "com.google.fonts/check/metadata/license",

--- a/tests/checks/googlefonts_test.py
+++ b/tests/checks/googlefonts_test.py
@@ -10,8 +10,6 @@ from fontTools.ttLib import TTFont
 
 from fontbakery.checks.googlefonts.conditions import (
     expected_font_names,
-    GF_TAGS_SHEET_URL,
-    GF_TAGS_SHEET_URL2,
 )
 from fontbakery.checks.googlefonts.glyphset import can_shape
 from fontbakery.codetesting import (
@@ -4946,35 +4944,6 @@ def test_check_varfont_bold_wght_coord():
     del ttFont["fvar"].instances[3]
     ttFont["fvar"].axes[0].maxValue = 600
     assert_results_contain(check(ttFont), SKIP, "no-bold-weight")
-
-
-def test_check_metadata_has_tags(requests_mock):
-    """The font has tags in the GF Tags spreadsheet"""
-    check = CheckTester("com.google.fonts/check/metadata/has_tags")
-
-    fake_gf_tags_sheet = (
-        "Family,Family Dir,Existing Category\n"
-        ",,\n,,\n,,\n,,\n,,\n"
-        "Merriweather,merriweather,SERIF\n"
-    )
-    requests_mock.get(GF_TAGS_SHEET_URL, text=fake_gf_tags_sheet)
-    fake_gf_tags_sheet2 = (
-        "Timestamp,Email Address,Family Name (name ID 1/16),,Category\n"
-        ",,\n,,\n,,\n,,\n,,\n"
-    )
-    requests_mock.get(GF_TAGS_SHEET_URL2, text=fake_gf_tags_sheet2)
-
-    font = "data/test/merriweather/Merriweather-Regular.ttf"
-    assert_PASS(check(font), "with a name that's in the spreadsheet...")
-
-    md = Font(font).family_metadata
-    md.name = "Not Merriweather"
-    assert_results_contain(
-        check(MockFont(file=font, family_metadata=md)),
-        FATAL,
-        "no-tags",
-        "with a name that doesn't appear...",
-    )
 
 
 def test_check_metadata_minisite_url():


### PR DESCRIPTION
## Description

We've stopped allowing designers to tag their own families. Instead the on call google/fonts repo maintainer will tag the families onboarded for the week. 

To ensure that no families remain untagged, the google/fonts repo will have its own tool to ensure that every family is tagged. It will be triggered when the on call maintainer submits the push lists.

## Checklist
- [X] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

