### PR TITLE
Move `check/aat` to Universal profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ##  Upcoming release: 0.12.11 (2024-Aug-??)
-  - ...
+### Migration of checks
+#### Moved to the Universal profile
+  - **[com.google.fonts/check/aat]:** from the Google Fonts profile. (PR #4820)
 
 
 ##  0.12.10 (2024-Aug-14)

--- a/Lib/fontbakery/checks/googlefonts/tables.py
+++ b/Lib/fontbakery/checks/googlefonts/tables.py
@@ -6,7 +6,9 @@ from fontbakery.prelude import check, Message, WARN, FAIL
     rationale="""
         Apple's TrueType reference manual [1] describes SFNT tables not in the
         Microsoft OpenType specification [2] and these can sometimes sneak into final
-        release files, but Google Fonts should only have OpenType tables.
+        release files.
+
+        This check ensures fonts only have OpenType tables.
 
         [1] https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html
         [2] https://docs.microsoft.com/en-us/typography/opentype/spec/
@@ -16,8 +18,6 @@ from fontbakery.prelude import check, Message, WARN, FAIL
 def com_google_fonts_check_aat(ttFont):
     """Are there unwanted Apple tables?"""
     UNWANTED_TABLES = {
-        "EBSC",
-        "Zaph",
         "acnt",
         "ankr",
         "bdat",
@@ -25,6 +25,7 @@ def com_google_fonts_check_aat(ttFont):
         "bloc",
         "bmap",
         "bsln",
+        "EBSC",
         "fdsc",
         "feat",
         "fond",
@@ -39,6 +40,7 @@ def com_google_fonts_check_aat(ttFont):
         "prop",
         "trak",
         "xref",
+        "Zaph",
     }
     unwanted_tables_found = []
     for table in ttFont.keys():
@@ -52,7 +54,7 @@ def com_google_fonts_check_aat(ttFont):
             f"Unwanted AAT tables were found"
             f" in the font and should be removed, either by"
             f" fonttools/ttx or by editing them using the tool"
-            f" they built with:\n\n"
+            f" they're built with:\n\n"
             f" {unwanted_list}",
         )
 

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -44,7 +44,6 @@ PROFILE = {
             "com.google.fonts/check/points_out_of_bounds",
         ],
         "Google Fonts": [
-            "com.google.fonts/check/aat",
             "com.google.fonts/check/fvar_name_entries",
             "com.google.fonts/check/varfont_duplicate_instance_names",
             "com.google.fonts/check/varfont/bold_wght_coord",  # IS_OVERRIDDEN
@@ -146,6 +145,7 @@ PROFILE = {
             # "com.google.fonts/check/STAT_strings",
             # "com.google.fonts/check/transformed_components",
             # ---
+            "com.google.fonts/check/aat",
             "com.google.fonts/check/family/win_ascent_and_descent",  # IS_OVERRIDDEN
             "com.google.fonts/check/fontbakery_version",  # IS_OVERRIDDEN
             "com.google.fonts/check/name/trailing_spaces",  # IS_OVERRIDDEN

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -116,7 +116,6 @@ PROFILE = {
             "com.google.fonts/check/outline_direction",
         ],
         "Font File Checks": [
-            "com.google.fonts/check/aat",
             "com.google.fonts/check/canonical_filename",
             "com.google.fonts/check/cjk_not_enough_glyphs",
             "com.google.fonts/check/cjk_vertical_metrics",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -83,7 +83,6 @@ PROFILE = {
             "com.google.fonts/check/varfont/consistent_axes",
             "com.google.fonts/check/smart_dropout",  # OVERRIDEN
             "com.google.fonts/check/vttclean",
-            "com.google.fonts/check/aat",
             "com.google.fonts/check/fvar_name_entries",
             # "com.google.fonts/check/ligature_carets", # PERMANENTLY EXCLUDED
             # "com.google.fonts/check/kerning_for_non_ligated_sequences", # PERMANENTLY EXCLUDED
@@ -173,6 +172,7 @@ PROFILE = {
             "com.google.fonts/check/italic_axis_last",
         ],
         "Universal Checks": [
+            "com.google.fonts/check/aat",
             "com.google.fonts/check/name/trailing_spaces",
             "com.google.fonts/check/family/win_ascent_and_descent",
             # "com.google.fonts/check/os2_metrics_match_hhea", # Removed in favor of

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -21,6 +21,7 @@ PROFILE = {
             "com.daltonmaag/check/designspace_has_consistent_groups",
         ],
         "Universal Profile Checks": [
+            "com.google.fonts/check/aat",
             "com.google.fonts/check/alt_caron",
             "com.google.fonts/check/arabic_high_hamza",
             "com.google.fonts/check/arabic_spacing_symbols",


### PR DESCRIPTION
**com.google.fonts/check/aat**
Migrated from the Google Fonts profile.

Among the vendor-specific profiles, only the Microsoft one did not include this check.

Also:
* Its rationale text was updated to remove references to Google Fonts.
* The list of tables was sorted alphabetically.

(PR #4820)