### PR TITLE
typoascender_exceeds_Agrave: downgrade to warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Universal profile
   - **[name/family_and_style_max_length"]:** Use nameID 16 (Typographic family name) to determine name length if it exists. (PR #4811)
+  - **[typoascender_exceeds_Agrave]:** Downgrade from FAIL to WARN. (PR #4828 / issue #3170)
 
 ### Migration of checks
 #### Moved from Fontwerk to OpenType profile

--- a/Lib/fontbakery/checks/metrics.py
+++ b/Lib/fontbakery/checks/metrics.py
@@ -314,7 +314,7 @@ def check_typoascender_exceeds_Agrave(ttFont):
     typoAscender = ttFont_copy["OS/2"].sTypoAscender
 
     if typoAscender < yMax:
-        yield FAIL, Message(
+        yield WARN, Message(
             "typoAscender",
             f"OS/2.sTypoAscender value should be greater than {yMax},"
             f" but got {typoAscender} instead",


### PR DESCRIPTION
As Guido mentioned in his comment, https://github.com/fonttools/fontbakery/issues/3170#issuecomment-2340706002. I don't think we can blindly apply a FAIL to this check since there are situations where you may want to break this rule.

## Description
Fixes #4827 https://github.com/fonttools/fontbakery/issues/3170#issuecomment-2340706002



## Checklist
- [X] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

