### PR TITLE
Clarify log-message about glyphs that seem to be spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ##  Upcoming release: 0.13.0 (2024-Sep-??)
 ### Changes to existing checks
+#### On the Opentype profile
+  - **[opentype/gdef_spacing_marks]:** Clarify log-message about glyphs that seem to be spacing. (issue #4824)
+
 #### On the Universal profile
   - **[name/family_and_style_max_length"]:** Use nameID 16 (Typographic family name) to determine name length if it exists. (PR #4811)
   - **[typoascender_exceeds_Agrave]:** Downgrade from FAIL to WARN. (PR #4828 / issue #3170)

--- a/Lib/fontbakery/checks/opentype/gdef.py
+++ b/Lib/fontbakery/checks/opentype/gdef.py
@@ -63,8 +63,9 @@ def check_gdef_spacing_marks(ttFont, config):
             formatted_list = "\t " + pretty_print_list(config, sorted(glyphs), sep=", ")
             yield WARN, Message(
                 "spacing-mark-glyphs",
-                f"The following spacing glyphs may be in"
-                f" the GDEF mark glyph class by mistake:\n"
+                f"The following glyphs seem to be spacing (because they have width > 0"
+                f" on the hmtx table) so they may be in the GDEF mark glyph class"
+                f" by mistake, or they should have zero width instead:\n"
                 f"{formatted_list}",
             )
     else:


### PR DESCRIPTION
**opentype/gdef_spacing_marks**
on the `Opentype` profile.

(issue #4824)