### PR TITLE
Avoid mutation of `TTFont` to fix issues with concurrent tests

### DIFF
--- a/Lib/fontbakery/checks/glyphset.py
+++ b/Lib/fontbakery/checks/glyphset.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from fontbakery.constants import (
     NameID,
     PlatformID,
@@ -369,6 +371,11 @@ def check_soft_hyphen(ttFont):
 )
 def unreachable_glyphs(ttFont, config):
     """Check font contains no unreachable glyphs"""
+
+    # remove_lookup_outputs() mutates the TTF; deep copy to avoid this, and so
+    # avoid issues with concurrent tests that also use ttFont.
+    # See https://github.com/fonttools/fontbakery/issues/4834
+    ttFont = deepcopy(ttFont)
 
     def remove_lookup_outputs(all_glyphs, lookup):
         if lookup.LookupType == 1:  # Single:

--- a/tests/test_checks_universal.py
+++ b/tests/test_checks_universal.py
@@ -1053,15 +1053,20 @@ def test_check_unreachable_glyphs():
         assert glyph not in message
 
     ttFont = TTFont(TEST_FILE("notosansmath/NotoSansMath-Regular.ttf"))
+    ttFont.ensureDecompiled()  # (required for mock glyph removal below)
+    glyph_order = ttFont.getGlyphOrder()
+
     # upWhiteMediumTriangle is used as a component in circledTriangle,
     # since CFF does not have composites it became unused.
     # So that is a build tooling issue.
     message = assert_results_contain(check(ttFont), WARN, "unreachable-glyphs")
     assert "upWhiteMediumTriangle" in message
-    assert "upWhiteMediumTriangle" in ttFont.glyphOrder
+    assert "upWhiteMediumTriangle" in glyph_order
 
-    # Other than that problem, no other glyphs are unreachable:
-    ttFont.glyphOrder.remove("upWhiteMediumTriangle")
+    # Other than that problem, no other glyphs are unreachable;
+    # Remove the glyph and then try again.
+    glyph_order.remove("upWhiteMediumTriangle")
+    ttFont.setGlyphOrder(glyph_order)
     assert "upWhiteMediumTriangle" not in ttFont.glyphOrder
     assert_PASS(check(ttFont))
 


### PR DESCRIPTION
Although the mutation is reversed, it could still have interfered with `TTFont` instances being used concurrently by other tests.

Before undrafting, I will test to see if this fixes #4834.

(even if not, the change may prevent similar issues in the future, and so we may wish to merge anyway)

## Checklist

- [ ] Update `CHANGELOG.md`
- [ ] Wait for the tests to pass
- [ ] Request a review

