### PR TITLE
googlefonts/axes_match: check added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ A more detailed list of changes is available in the corresponding milestones for
   - As this is the **"a0" pre-release**, there may be additional migrations and renames of checks, before we make an actual **v0.13.0** release. Please open an issue if you have suggestions of better names or better profile allocations.
   - **[FontBakeryCondition:remote_styles]:** Use the Google Fonts family name to fetch the family. (PR #4838)
 
+### New checks
+#### Added to the Google Fonts profile
+  - **[googlefonts/axes_match]**: Check the font isn't missing any axes and the axes have the same range as the Google Fonts version. (PR #4836)
+
 ### Changes to existing checks
 #### On the Google Fonts profile
   - **[googlefonts/glyphsets/shape_languages]:** Improve formatting of output to avoid excessively long reports. (issue #4781)

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/varfont.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/varfont.py
@@ -5,6 +5,51 @@ from fontbakery.utils import markdown_table
 
 
 @check(
+    id="googlefonts/axes_match",
+    conditions=["remote_style"],
+    rationale="""
+        An updated font family must include the same axes found in the Google "
+        Fonts version, with the same axis ranges.
+    """,
+)
+def check_axes_match(ttFont, remote_style):
+    """Check if the axes match between the font and the Google Fonts version."""
+    remote_axes = {
+        a.axisTag: (a.minValue, a.maxValue) for a in remote_style["fvar"].axes
+    }
+    font_axes = {a.axisTag: (a.minValue, a.maxValue) for a in ttFont["fvar"].axes}
+
+    missing_axes = []
+    for axis, remote_axis_range in remote_axes.items():
+        if axis not in font_axes:
+            missing_axes.append(axis)
+            continue
+        axis_range = font_axes[axis]
+        axis_min, axis_max = axis_range
+        remote_axis_min, remote_axis_max = remote_axis_range
+        if axis_min > remote_axis_min:
+            yield FAIL, Message(
+                "axis-min-out-of-range",
+                f"Axis '{axis}' min value is out of range."
+                f" Expected '{remote_axis_min}', got '{axis_min}'.",
+            )
+        if axis_max < remote_axis_max:
+            yield FAIL, Message(
+                "axis-max-out-of-range",
+                f"Axis {axis} max value is out of range."
+                f" Expected {remote_axis_max}, got {axis_max}.",
+            )
+
+    if missing_axes:
+        yield FAIL, Message(
+            "missing-axes",
+            f"Missing axes: {', '.join(missing_axes)}",
+        )
+    else:
+        yield PASS, "Axes match Google Fonts version."
+
+
+@check(
     id="googlefonts/STAT",
     conditions=["is_variable_font", "expected_font_names"],
     rationale="""

--- a/Lib/fontbakery/profiles/fontwerk.py
+++ b/Lib/fontbakery/profiles/fontwerk.py
@@ -17,6 +17,7 @@ PROFILE = {
         "fontdata_namecheck",
     ],
     "pending_review": [
+        "googlefonts/axes_match",
         "typographic_family_name",
         "vtt_volt_data",  # very similar to vttclean, may be a good idea to merge them.
         #

--- a/Lib/fontbakery/profiles/googlefonts.py
+++ b/Lib/fontbakery/profiles/googlefonts.py
@@ -150,6 +150,7 @@ PROFILE = {
             "googlefonts/version_bump",
             "googlefonts/vertical_metrics",
             "googlefonts/vertical_metrics_regressions",
+            "googlefonts/axes_match",
         ],
     },
     "configuration_defaults": {


### PR DESCRIPTION
## Description

When we update a family on Google Fonts, it must include the same axes and axes ranges as the previous release. If we don't, we'll end up breaking the googlefonts css2 api.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review


@felipesanches I'll finish this off tomorrow.