### PR TITLE
Shorten output of 'shape_languages' check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - As this is the **"a0" pre-release**, there may be additional migrations and renames of checks, before we make an actual **v0.13.0** release. Please open an issue if you have suggestions of better names or better profile allocations.
 
 ### Changes to existing checks
+#### On the Google Fonts profile
+  - **[googlefonts/glyphsets/shape_languages]:** Improve formatting of output to avoid excessively long reports. (issue #4781)
+
 #### On the Opentype profile
   - **[opentype/gdef_spacing_marks]:** Clarify log-message about glyphs that seem to be spacing. (issue #4824)
 

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -128,7 +128,7 @@ def split_camel_case(camelcase):
     return "".join(chars)
 
 
-def pretty_print_list(config, values, shorten=10, sep=", ", glue=" and "):
+def pretty_print_list(config, values, shorten=10, sep=", ", glue=" and ", quiet=False):
     if len(values) == 1:
         return str(values[0])
 
@@ -137,11 +137,10 @@ def pretty_print_list(config, values, shorten=10, sep=", ", glue=" and "):
 
     if shorten and len(values) > shorten + 2:
         joined_items_str = sep.join(map(str, values[:shorten]))
-        return (
-            f"{joined_items_str}{glue}{len(values) - shorten} more.\n"
-            f"\n"
-            f"Use -F or --full-lists to disable shortening of long lists."
-        )
+        msg = f"{joined_items_str}{glue}{len(values) - shorten} more."
+        if not quiet:
+            msg += "\n\nUse -F or --full-lists to disable shortening of long lists."
+        return msg
     else:
         joined_items_str = sep.join(map(str, values[:-1]))
         return f"{joined_items_str}{glue}{str(values[-1])}"


### PR DESCRIPTION
Improve formatting of output to avoid excessively long reports.

googlefonts/glyphsets/shape_languages
On the Google Fonts profile

(issue #4781)

![Screenshot from 2024-09-19 10-20-58](https://github.com/user-attachments/assets/905718e0-7604-46fa-8568-7245003fadf8)
