### PR TITLE
Don’t show clusters of checks which are omitted

### DIFF
--- a/Lib/fontbakery/reporters/templates/html/section.html
+++ b/Lib/fontbakery/reporters/templates/html/section.html
@@ -3,5 +3,7 @@
     {% for status in section.status_summary %}{{ status | emoticon }}{% endfor %}
 </span>
 {% for cluster in section["clustered_checks"] %}
+    {% if cluster is not omitted %}
     {% include "check.html" %}
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
This is a small fix to the HTML template. Currently all checks are being shown, even if the check *results* are omitted:

<img width="768" alt="Screenshot 2024-09-20 at 11 52 43" src="https://github.com/user-attachments/assets/2a3ee661-3d27-4879-8e56-bbc94eb712f7">

With this PR, checks with nothing to show are omitted.