### PR TITLE
WARN->FATAL on missing article image files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ##  Upcoming release: 0.13.0a2 (2024-Oct-??)
+### Changes to existing checks
+#### On the Google Fonts profile
+  - **[googlefonts/article/images]:** Missing image files are now reported at **FATAL** level. (issue #4848)
+
 ### Deprecated checks
 #### Removed from the Universal profile
   - **DEPRECATED - [whitespace_glyphnames]:** This check lacked a solid enough rationale. We may want to substitute it in the future by a full AGL-compliance check, if needed. (issue #4851)

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/article.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/article.py
@@ -1,6 +1,6 @@
 import os
 
-from fontbakery.prelude import check, Message, FAIL, WARN, PASS
+from fontbakery.prelude import check, Message, FATAL, FAIL, WARN, PASS
 
 
 @check(
@@ -78,7 +78,7 @@ def check_article_images(config, family_directory):
         yield WARN, Message("missing-visual-asset", "Article page lacks visual assets.")
 
     if missing_files:
-        yield WARN, Message(
+        yield FATAL, Message(
             "missing-visual-file",
             f"Visual asset files are missing:\n{bullet_list(config, missing_files)}",
         )

--- a/tests/test_checks_googlefonts.py
+++ b/tests/test_checks_googlefonts.py
@@ -4331,7 +4331,7 @@ def test_check_article_images():
     # Test case for ARTICLE with missing visual files
     family_directory = portable_path("data/test/article_missing_visual_file")
     assert_results_contain(
-        check(MockFont(family_directory=family_directory)), WARN, "missing-visual-file"
+        check(MockFont(family_directory=family_directory)), FATAL, "missing-visual-file"
     )
 
     #    TODO:


### PR DESCRIPTION
Missing article image files are now reported at **FATAL** level.

**googlefonts/article/images** on the `Google Fonts` profile.

(issue #4848)