### PR TITLE
Move opentype/name/no_copyright_on_description to Universal profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ##  Upcoming release: 0.13.0a2 (2024-Oct-??)
+### Migration of checks
+#### Moved from OpenType to Universal profile
+  - **[name/no_copyright_on_description]**: Adding copyright information to the description name entry is bad practice but is not a breach of specification (issue #4857)
+
 ### Changes to existing checks
 #### On the Google Fonts profile
   - **[googlefonts/article/images]:** Missing image files are now reported at **FATAL** level. (issue #4848)

--- a/Lib/fontbakery/checks/name.py
+++ b/Lib/fontbakery/checks/name.py
@@ -294,3 +294,32 @@ def check_name_no_mac_entries(ttFont):
     for rec in ttFont["name"].names:
         if rec.platformID == 1:
             yield FAIL, Message("mac-names", f"Please remove name ID {rec.nameID}")
+
+
+@check(
+    id="name/no_copyright_on_description",
+    rationale="""
+        The name table in a font file contains strings about the font;
+        there are entries for a copyright field and a description. If the
+        copyright entry is being used correctly, then there should not
+        be any copyright information in the description entry.
+    """,
+    proposal="https://github.com/fonttools/fontbakery/issues/4829",  # legacy check
+)
+def check_name_no_copyright_on_description(ttFont):
+    """Description strings in the name table must not contain copyright info."""
+    for name in ttFont["name"].names:
+        if (
+            "opyright" in name.string.decode(name.getEncoding())
+            and name.nameID == NameID.DESCRIPTION
+        ):
+            yield FAIL, Message(
+                "copyright-on-description",
+                f"Some namerecords with"
+                f" ID={NameID.DESCRIPTION} (NameID.DESCRIPTION)"
+                f" containing copyright info should be removed"
+                f" (perhaps these were added by a longstanding"
+                f" FontLab Studio 5.x bug that copied"
+                f" copyright notices to them.)",
+            )
+            break

--- a/Lib/fontbakery/checks/opentype/name.py
+++ b/Lib/fontbakery/checks/opentype/name.py
@@ -38,35 +38,6 @@ def check_name_empty_records(ttFont):
             )
 
 
-@check(
-    id="opentype/name/no_copyright_on_description",
-    rationale="""
-        The name table in a font file contains strings about the font;
-        there are entries for a copyright field and a description. If the
-        copyright entry is being used correctly, then there should not
-        be any copyright information in the description entry.
-    """,
-    proposal="https://github.com/fonttools/fontbakery/issues/4829",  # legacy check
-)
-def check_name_no_copyright_on_description(ttFont):
-    """Description strings in the name table must not contain copyright info."""
-    for name in ttFont["name"].names:
-        if (
-            "opyright" in name.string.decode(name.getEncoding())
-            and name.nameID == NameID.DESCRIPTION
-        ):
-            yield FAIL, Message(
-                "copyright-on-description",
-                f"Some namerecords with"
-                f" ID={NameID.DESCRIPTION} (NameID.DESCRIPTION)"
-                f" containing copyright info should be removed"
-                f" (perhaps these were added by a longstanding"
-                f" FontLab Studio 5.x bug that copied"
-                f" copyright notices to them.)",
-            )
-            break
-
-
 def PANOSE_is_monospaced(panose):
     """
     This function considers the following PANOSE combinations monospace:

--- a/Lib/fontbakery/profiles/adobefonts.py
+++ b/Lib/fontbakery/profiles/adobefonts.py
@@ -5,7 +5,6 @@ Checks for Adobe Fonts (formerly known as Typekit).
 PROFILE = {
     "include_profiles": ["universal"],
     "exclude_checks": [
-        "opentype/name/no_copyright_on_description",
         "opentype/xavgcharwidth",
         #
         "designspace_has_consistent_codepoints",
@@ -13,6 +12,7 @@ PROFILE = {
         "designspace_has_consistent_groups",
         "designspace_has_default_master",
         "designspace_has_sources",
+        "name/no_copyright_on_description",
         "ufolint",
         "ufo_features_default_languagesystem",
         "ufo_recommended_fields",

--- a/Lib/fontbakery/profiles/opentype.py
+++ b/Lib/fontbakery/profiles/opentype.py
@@ -40,7 +40,6 @@ PROFILE = {
             "opentype/name/empty_records",
             "opentype/name/italic_names",
             "opentype/name/match_familyname_fullfont",
-            "opentype/name/no_copyright_on_description",
             "opentype/name/postscript_name_consistency",
             "opentype/name/postscript_vs_cff",
             "opentype/points_out_of_bounds",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -5,16 +5,17 @@ PROFILE = {
     ],
     "exclude_checks": [
         "opentype/family/panose_familytype",
-        "opentype/name/no_copyright_on_description",
         "opentype/vendor_id",
-        "superfamily/list",
+        #
         "alt_caron",
         "cjk_chws_feature",
         "family/single_directory",  # Sometimes we want to run the profile on multiple fonts.
         "fontbakery_version",
         "math_signs_width",  # It really depends on the design and the intended use to make math symbols the same width.
+        "name/no_copyright_on_description",
         "os2_metrics_match_hhea",  # Removed in favor of new vmetrics check
         "STAT_strings",  # replaced by adobefonts/STAT_strings
+        "superfamily/list",
     ],
     "pending_review": [
         "typenetwork/fstype",  # DEPRECATED: if not really needed anymore, it would be good to delete it from the repo.

--- a/Lib/fontbakery/profiles/universal.py
+++ b/Lib/fontbakery/profiles/universal.py
@@ -61,6 +61,7 @@ PROFILE = {
             "name/ascii_only_entries",
             "name/family_and_style_max_length",
             "name/trailing_spaces",
+            "name/no_copyright_on_description",
             "no_debugging_tables",
             "no_mac_entries",
             "os2_metrics_match_hhea",

--- a/tests/test_checks_name.py
+++ b/tests/test_checks_name.py
@@ -225,3 +225,21 @@ def test_check_name_no_mac_entries():
 
     font = TEST_FILE("source-sans-pro/OTF/SourceSansPro-Regular.otf")
     assert_PASS(check(font), "with a font without Mac names")
+
+
+def test_check_name_no_copyright_on_description():
+    """Description strings in the name table must not contain copyright info."""
+    check = CheckTester("name/no_copyright_on_description")
+
+    # Our reference Mada Regular is know to be good here.
+    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+    assert_PASS(check(ttFont), "with a good font...")
+
+    # here we add a "Copyright" string to a NameID.DESCRIPTION
+    for i, name in enumerate(ttFont["name"].names):
+        if name.nameID == NameID.DESCRIPTION:
+            ttFont["name"].names[i].string = "Copyright".encode(name.getEncoding())
+
+    assert_results_contain(
+        check(ttFont), FAIL, "copyright-on-description", "with a bad font..."
+    )

--- a/tests/test_checks_opentype_name.py
+++ b/tests/test_checks_opentype_name.py
@@ -45,26 +45,6 @@ def test_check_name_empty_records():
     )
 
 
-def test_check_name_no_copyright_on_description():
-    """Description strings in the name table
-    must not contain copyright info.
-    """
-    check = CheckTester("opentype/name/no_copyright_on_description")
-
-    # Our reference Mada Regular is know to be good here.
-    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
-    assert_PASS(check(ttFont), "with a good font...")
-
-    # here we add a "Copyright" string to a NameID.DESCRIPTION
-    for i, name in enumerate(ttFont["name"].names):
-        if name.nameID == NameID.DESCRIPTION:
-            ttFont["name"].names[i].string = "Copyright".encode(name.getEncoding())
-
-    assert_results_contain(
-        check(ttFont), FAIL, "copyright-on-description", "with a bad font..."
-    )
-
-
 def test_check_monospace():
     """Checking correctness of monospaced metadata."""
     check = CheckTester("opentype/monospace")


### PR DESCRIPTION
Adding copyright information to the description name entry is bad practice but is not a breach of specification.

* [name/no_copyright_on_description]: renamed (removing the 'opentype/' prefix) and moved from OpenType to Universal profile.

(issue #4857)