### PR TITLE
Fix errors when testing Zain family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ##  Upcoming release: 0.13.0a2 (2024-Oct-11)
+### Noteworthy code-changes
+  - **[FontBakeryCondition:remote_styles]:** Fetching static fonts no longer raises an error.
+
 ### Migration of checks
 #### Moved from OpenType to Universal profile
   - **[name/no_copyright_on_description]**: Adding copyright information to the description name entry is bad practice but is not a breach of specification. (issue #4857)
@@ -13,6 +16,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Google Fonts profile
   - **[googlefonts/article/images]:** Missing image files are now reported at **FATAL** level. (issue #4848)
+  - **[googlefonts/axes_match]:** Only run on variable fonts. This stops fontbakery producing an error on static fonts.
 
 ### Deprecated checks
 #### Removed from the Universal profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-##  Upcoming release: 0.13.0a2 (2024-Oct-11)
+##  Upcoming release: 0.13.0a2 (2024-Oct-16)
 ### Noteworthy code-changes
-  - **[FontBakeryCondition:remote_styles]:** Fetching static fonts no longer raises an error.
+  - **[FontBakeryCondition:remote_styles]:** Fetching static fonts no longer raises an error. (PR # #4863)
 
 ### Migration of checks
 #### Moved from OpenType to Universal profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 #### On the Google Fonts profile
   - **[googlefonts/article/images]:** Missing image files are now reported at **FATAL** level. (issue #4848)
-  - **[googlefonts/axes_match]:** Only run on variable fonts. This stops fontbakery producing an error on static fonts.
+  - **[googlefonts/axes_match]:** Only run on variable fonts. This stops fontbakery producing an error on static fonts. (PR # #4863)
 
 ### Deprecated checks
 #### Removed from the Universal profile

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/conditions.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/conditions.py
@@ -315,7 +315,7 @@ def remote_styles(font):
                 )
                 rstyles[inst_subfamily] = remote_font
         else:
-            rstyles[font["name"].getBestSubFamilyName()] = remote_font
+            rstyles[remote_font["name"].getBestSubFamilyName()] = remote_font
     return rstyles
 
 

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/varfont.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/varfont.py
@@ -6,7 +6,7 @@ from fontbakery.utils import markdown_table
 
 @check(
     id="googlefonts/axes_match",
-    conditions=["remote_style"],
+    conditions=["is_variable_font", "remote_style"],
     rationale="""
         An updated font family must include the same axes found in the Google "
         Fonts version, with the same axis ranges.


### PR DESCRIPTION
## Description

The google/fonts ci is raising a lot of ERRORS for the Zain family, which consists of static fonts, https://github.com/google/fonts/actions/runs/11362337351/job/31603978902. It appears that fetching remote styles for static fonts is broken and the axes_match check is also attempting to be run on static fonts.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

