### PR TITLE
`opentype/vendor_id`: pad vendor ID from config to accurately match OS/2 vendor ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Universal Profile
   - **[name/ascii_only_entries]:** Renamed to **[name/char_restrictions]**; Improve and apply character repertoire restrictions only where necessary. (PR #4869 / issue #1718)
+  - **[opentype/vendor_id]:** Pads the configured vendor ID to four characters, to accurately match what it will actually be in the OS/2 table.
 
 
 ##  0.13.0a2 (2024-Oct-16)

--- a/Lib/fontbakery/checks/opentype/os2.py
+++ b/Lib/fontbakery/checks/opentype/os2.py
@@ -340,7 +340,10 @@ def check_vendor_id(config, ttFont):
         yield FAIL, Message("lacks-OS/2", "The required OS/2 table is missing.")
         return
 
-    config_vendor_id = config["vendor_id"]
+    # vendor ID is a 4-byte ASCII string, per the OpenType spec
+    # so this pads the string to 4 bytes if it's shorter
+    config_vendor_id = config["vendor_id"].ljust(4)
+
     font_vendor_id = ttFont["OS/2"].achVendID
 
     if config_vendor_id != font_vendor_id:


### PR DESCRIPTION
## Description

When checking a vendor ID against a config file, if the vendor ID is not four characters, it will always fail – even if the configured vendor ID really does match the vendor ID.

This is because the vendor ID gets stored in the OS/2 table as a four-byte tag, [per the OpenType spec](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#achvendid): "All vendor IDs use the Tag data type, which is equivalent to a four-character string composed of a limited set of ASCII characters."

For example, a font from `LLD` will currently fail, because in the OS/2 table, it is saved as `LLD ` (with the trailing space).

ufo2ft handles this by padding the vendor ID, from what I can tell: https://github.com/googlefonts/ufo2ft/blob/d15ef8f6f235804733c6e2ea5f01f39aafb92f45/Lib/ufo2ft/outlineCompiler.py#L675

So, this update adopts the ufo2ft approach, and tweaks the check to also pad the configured vendor ID, to check whether it is equivalent to what it would be in the OS/2 table.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

