### PR TITLE
overlapping_path_segments: downgrade to WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[name/ascii_only_entries]:** Renamed to **[name/char_restrictions]**; Improve and apply character repertoire restrictions only where necessary. (PR #4869 / issue #1718)
   - **[opentype/vendor_id]:** Pads the configured vendor ID to four characters, to accurately match what it will actually be in the OS/2 table.
 
+#### On the Outline Profile
+  - **[overlapping_path_segments]:** Downgrade to warn since its raising many false positives.
+
 
 ##  0.13.0a2 (2024-Oct-16)
 ### Noteworthy code-changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 #### On the Universal Profile
   - **[name/ascii_only_entries]:** Renamed to **[name/char_restrictions]**; Improve and apply character repertoire restrictions only where necessary. (PR #4869 / issue #1718)
-  - **[opentype/vendor_id]:** Pads the configured vendor ID to four characters, to accurately match what it will actually be in the OS/2 table.
+  - **[overlapping_path_segments]:** Downgrade to warn since its raising many false positives. (PR #4872)
 
-#### On the Outline Profile
-  - **[overlapping_path_segments]:** Downgrade to warn since its raising many false positives.
+#### On the OpenType Profile
+  - **[opentype/vendor_id]:** Pads the configured vendor ID to four characters, to accurately match what it will actually be in the OS/2 table. (PR # #4870)
 
 
 ##  0.13.0a2 (2024-Oct-16)

--- a/Lib/fontbakery/checks/outline.py
+++ b/Lib/fontbakery/checks/outline.py
@@ -412,7 +412,7 @@ def check_overlapping_path_segments(ttFont, outlines_dict, config):
                     )
                 seen.add(normal)
     if failed:
-        yield FAIL, Message(
+        yield WARN, Message(
             "overlapping-path-segments",
             f"The following glyphs have overlapping path segments:\n\n"
             f"{bullet_list(config, failed, bullet='*')}",

--- a/Lib/fontbakery/checks/outline.py
+++ b/Lib/fontbakery/checks/outline.py
@@ -5,7 +5,7 @@ from beziers.path import BezierPath
 
 from fontbakery.callable import condition, check
 from fontbakery.testable import Font
-from fontbakery.status import PASS, WARN, FAIL
+from fontbakery.status import PASS, WARN
 from fontbakery.message import Message
 from fontbakery.utils import bullet_list
 

--- a/tests/test_checks_outline.py
+++ b/tests/test_checks_outline.py
@@ -162,7 +162,7 @@ def test_check_overlapping_path_segments():
     # Check a font that contains overlapping path segments
     filename = TEST_FILE("overlapping_path_segments/Figtree[wght].ttf")
     results = check(filename)
-    assert_results_contain(results, FAIL, "overlapping-path-segments")
+    assert_results_contain(results, WARN, "overlapping-path-segments")
 
     # check a font that doesn't contain overlapping path segments
     filename = TEST_FILE("merriweather/Merriweather-Regular.ttf")

--- a/tests/test_checks_outline.py
+++ b/tests/test_checks_outline.py
@@ -1,5 +1,5 @@
 from fontTools.ttLib import TTFont
-from fontbakery.status import WARN, SKIP, FAIL
+from fontbakery.status import WARN, SKIP
 from fontbakery.codetesting import (
     assert_results_contain,
     CheckTester,


### PR DESCRIPTION
## Description

This check is currently raising many false positives. Some segment may overlap but it isn't causing any rendering artifacts. I've also noticed that I'm not able to replicate https://github.com/google/fonts/issues/7594 anymore so I suspect CoreText may have fixed it.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

