### PR TITLE
Morf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### On the TypeNetwork profile
   - **[typenetwork/usweightclass]:** Fix weightclass check. (PR #4878)
 
+#### On the Google Fonts Profile
+  - **[googlefonts/STAT/axisregistry]:** Allow MORF axis to have user defined AxisValues (PR #4874)
+
 ### Deprecated checks
 #### Removed from the OpenType profile
   - **DEPRECATED - [opentype/dsig]:** Merged into **[unwanted_tables]** on the `Universal` profile. (issue #4865)

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/axisregistry.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/axisregistry.py
@@ -170,6 +170,10 @@ def check_STAT_axisregistry_names(ttFont):
             continue
 
         axis = ttFont["STAT"].table.DesignAxisRecord.Axis[axis_value.AxisIndex]
+        # If a family has a MORF axis, we allow users to define their own
+        # axisValues for this axis.
+        if axis.AxisTag == "MORF":
+            continue
         if axis.AxisTag in GFAxisRegistry().keys():
             fallbacks = GFAxisRegistry()[axis.AxisTag].fallback
             fallbacks = {f.name: f.value for f in fallbacks}

--- a/tests/test_checks_googlefonts.py
+++ b/tests/test_checks_googlefonts.py
@@ -3521,6 +3521,8 @@ def test_check_STAT_gf_axisregistry():
     """
     Validate STAT particle names and values match the fallback names in GFAxisRegistry.
     """
+    from fontTools.otlLib.builder import buildStatTable
+
     check = CheckTester("googlefonts/STAT/axisregistry")
 
     # Our reference varfont, CabinVF,
@@ -3548,6 +3550,33 @@ def test_check_STAT_gf_axisregistry():
     # requires them.
     ttFont["STAT"].table.AxisValueArray = None
     assert_results_contain(check(ttFont), FAIL, "missing-axis-values")
+
+    # Let's add a MORF Axis with custom axisvalues
+    stat = [
+        {
+            "tag": "MORF",
+            "name": "Morph",
+            "values": [
+                {"name": "Foo", "value": 0},
+                {"name": "Bar", "value": 100},
+            ],
+        },
+        {
+            "tag": "wght",
+            "name": "Weight",
+            "values": [
+                {"name": "Regular", "value": 400, "flags": 0x2},
+                {"name": "Bold", "value": 700},
+            ],
+        },
+    ]
+    buildStatTable(ttFont, stat)
+    assert_PASS(check(ttFont))
+
+    # Let's make a weight axisvalue incorrect.
+    stat[1]["values"][1]["value"] = 800
+    buildStatTable(ttFont, stat)
+    assert_results_contain(check(ttFont), FAIL, "bad-coordinate")
 
 
 def test_check_metadata_consistent_axis_enumeration():


### PR DESCRIPTION
## Description

We released Kablammo last year. The family doesn't have a weight axis, only a Morph (MORF) axis. Since the morph axis is pretty ambiguous, we decided to let designers have their own custom AxisValues for this axis. It would've been a tragedy to release this family with only a since Weight instance since the designer had spent a lot of time drawing different styles for the morph axis 

<img width="395" alt="Screenshot 2024-10-30 at 10 28 38" src="https://github.com/user-attachments/assets/a21b7489-9985-4c05-bf82-1a6e434796e6">

Zoink 0

<img width="390" alt="Screenshot 2024-10-30 at 10 28 54" src="https://github.com/user-attachments/assets/7ffd78a6-34c5-4441-bc85-4fda7ffa0134">

Bloop 20

<img width="390" alt="Screenshot 2024-10-30 at 10 29 08" src="https://github.com/user-attachments/assets/b1e128eb-5ed1-4950-bc6a-64ca80305d46">

Splat 40 

<img width="400" alt="Screenshot 2024-10-30 at 10 29 22" src="https://github.com/user-attachments/assets/d6eaebce-e2f4-4fc2-9dd9-c06ba1f95d21">

Eek 60

We're now in the process of releasing Agu Display which also just has a Morph axis.


## Checklist
- [X] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

