### PR TITLE
TypeNetwork profile update (2024-10-31) refactored by fsanches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,59 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-##  Upcoming release: 0.13.0 (a4?) (2024-Nov-??)
+##  Upcoming release: 0.13.0 (a5?) (2024-Nov-??)
+  - ...
+
+
+##  0.13.0a4 (2024-Nov-01)
+### Noteworthy release notes
+  - Thanks Guido Ferreyra for updating the TypeNetwork profile based on its "pending_review" list of recent checks that had been added since his last review (summary of changes listed below). **Other profile owners should consider doing the same.** (PR #4878)
+
+#### TypeNetwork review: approved checks:
+ - **opentype/cff_ascii_strings**
+ - **opentype/postscript_name**
+ - **opentype/varfont/family_axis_ranges**
+ - **opentype/weight_class_fvar**
+ - **googlefonts/negative_advance_width** (cherry-picked from gfonts profile)
+ - **googlefonts/STAT/axis_order** (cherry-picked from gfonts profile)
+ - **case_mapping**
+ - **fontdata_namecheck**
+ - **gsub/smallcaps_before_ligatures**
+ - **integer_ppem_if_hinted**
+ - **legacy_accents**
+ - **no_debugging_tables**
+ - **tabular_kerning**
+ - **typoascender_exceeds_Agrave**
+ - **typographic_family_name**
+ - **varfont/duplexed_axis_reflow**
+ - **varfont/instances_in_order**
+ - **name/ascii_only_entries**
+ - **dotted_circle**
+
+#### TypeNetwork review: excluded checks:
+  - **caps_vertically_centered**
+  - **cmap/format_12**
+  - **cjk_not_enough_glyphs**
+  - **color_cpal_brightness** (Color font check)
+  - **colorfont_tables** (Color font check)
+  - **designspace_has_consistent_codepoints** (TypeNetwork doesn’t check designspace files.)
+  - **designspace_has_consistent_glyphset** (designspace files)
+  - **designspace_has_consistent_groups** (designspace files)
+  - **designspace_has_default_master** (designspace files)
+  - **designspace_has_sources** (designspace files)
+  - **empty_glyph_on_gid1_for_colrv0** (Color font check)
+  - **hinting_impact**
+  - **render_own_name**
+  - **vtt_volt_data** (Very similar to 'vttclean' check, it may be a good idea to merge them.)
+  - **varfont/unsupported_axes** (Despite discouraging its use, TN accepts fonts with ital axis.)
+  - **file_size**
+  - **fontval** (Temporarily disabled)
+  - **ufolint** (TypeNetwork doesn’t check .ufo files.)
+  - **ufo_features_default_languagesystem** (.ufo files)
+  - **ufo_recommended_fields** (.ufo files)
+  - **ufo_required_fields** (.ufo files)
+  - **ufo_unnecessary_fields** (.ufo files)
+
 ### Changes to existing checks
 ### On the TypeNetwork profile
   - **[typenetwork/usweightclass]:** Fix weightclass check. (PR #4878)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ##  Upcoming release: 0.13.0 (a4?) (2024-Nov-??)
+### Changes to existing checks
+### On the TypeNetwork profile
+  - **[typenetwork/usweightclass]:** Fix weightclass check. (PR #4878)
+
 ### Deprecated checks
 #### Removed from the OpenType profile
   - **DEPRECATED - [opentype/dsig]:** Merged into **[unwanted_tables]** on the `Universal` profile. (issue #4865)

--- a/Lib/fontbakery/checks/vendorspecific/typenetwork.py
+++ b/Lib/fontbakery/checks/vendorspecific/typenetwork.py
@@ -930,69 +930,6 @@ def check_family_valid_strikeout(ttFont):
 
 
 @check(
-    id="typenetwork/fstype",
-    rationale="""
-        The fsType in the OS/2 table is a legacy DRM-related field.
-        Type Network's EULA is more accurately represented by setting it to 4,
-        also known as 'Print & Preview'.
-
-        This setting indicates that the fonts may be embedded, and temporarily loaded
-        on the remote system, but documents that use it must not be editable.
-
-        More detailed info is available at:
-        https://docs.microsoft.com/en-us/typography/opentype/spec/os2#fstype
-    """,
-    proposal=["https://github.com/fonttools/fontbakery/pull/4260"],
-)
-def check_fstype(ttFont):
-    """Checking OS/2 fsType does not impose restrictions."""
-    value = ttFont["OS/2"].fsType
-
-    FSTYPE_RESTRICTIONS = {
-        0x0002: (
-            "* The font must not be modified, embedded or exchanged in"
-            " any manner without first obtaining permission of"
-            " the legal owner."
-        ),
-        0x0004: (
-            "The font may be embedded, and temporarily loaded on the"
-            " remote system, but documents that use it must"
-            " not be editable."
-        ),
-        0x0008: (
-            "The font may be embedded but must only be installed"
-            " temporarily on other systems."
-        ),
-        0x0100: ("The font may not be subsetted prior to embedding."),
-        0x0200: (
-            "Only bitmaps contained in the font may be embedded."
-            " No outline data may be embedded."
-        ),
-    }
-    restrictions = ""
-    for bit_mask in FSTYPE_RESTRICTIONS.keys():
-        if value & bit_mask:
-            restrictions += FSTYPE_RESTRICTIONS[bit_mask]
-
-    if value & 0b1111110011110001:
-        restrictions += (
-            "* There are reserved bits set, which indicates an invalid setting."
-        )
-
-    if value != 0x0004:
-        yield WARN, Message(
-            "no-preview-print",
-            f"In this font fsType is set to {value} meaning that:\n"
-            f"{restrictions}\n"
-            "\n"
-            "TN advises setting the fsType to bit 4, Print & Preview, which"
-            "matches TN’s EULA.",
-        )
-    else:
-        yield PASS, "OS/2 fsType is properly set to 'Print & Preview'."
-
-
-@check(
     id="typenetwork/composite_glyphs",
     rationale="""
         For performance reasons, it is recommended that TTF fonts use composite glyphs.

--- a/Lib/fontbakery/checks/vendorspecific/typenetwork.py
+++ b/Lib/fontbakery/checks/vendorspecific/typenetwork.py
@@ -671,7 +671,7 @@ def check_usweightclass(font, tn_expected_os2_weight):
     """Checking OS/2 usWeightClass."""
     failed = False
     expected_value = tn_expected_os2_weight["weightClass"]
-    weight_name = tn_expected_os2_weight["name"]
+    weight_name = tn_expected_os2_weight["name"].lower()
     os2_value = font.ttFont["OS/2"].usWeightClass
 
     fail_message = "OS/2 usWeightClass is '{}' when it should be '{}'."
@@ -705,25 +705,19 @@ def check_usweightclass(font, tn_expected_os2_weight):
                 "no-value", no_value_message.format(os2_value, weight_name)
             )
 
-        elif "Thin" in weight_name.split(" "):
+        elif "thin" in weight_name.split(" "):
             if os2_value not in expected_value:
                 failed = True
                 yield FAIL, Message(
                     "bad-value", fail_message.format(os2_value, expected_value)
                 )
-            if os2_value == 100:
-                failed = True
-                yield WARN, Message("warn-value", warn_message.format(os2_value, 250))
 
-        elif "ExtraLight" in weight_name.split(" "):
+        elif "extralight" in weight_name.split(" "):
             if os2_value not in expected_value:
                 failed = True
                 yield FAIL, Message(
                     "bad-value", fail_message.format(os2_value, expected_value)
                 )
-            if os2_value == 200:
-                failed = True
-                yield WARN, Message("warn-value", warn_message.format(os2_value, 275))
 
         elif os2_value != expected_value:
             failed = True

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -21,6 +21,11 @@ PROFILE = {
         "os2_metrics_match_hhea",  # Removed in favor of new vmetrics check
         "STAT_strings",  # replaced by adobefonts/STAT_strings
         "superfamily/list",
+        "ufolint",  #                             < TypeNetwork doesn’t check .ufo files.
+        "ufo_features_default_languagesystem",  # <
+        "ufo_recommended_fields",  #              <
+        "ufo_required_fields",  #                 <
+        "ufo_unnecessary_fields",  #              <
     ],
     "pending_review": [
         "opentype/cff_ascii_strings",
@@ -57,11 +62,6 @@ PROFILE = {
         "tabular_kerning",
         "typoascender_exceeds_Agrave",
         "typographic_family_name",
-        "ufolint",
-        "ufo_features_default_languagesystem",
-        "ufo_recommended_fields",
-        "ufo_required_fields",
-        "ufo_unnecessary_fields",
         "varfont/duplexed_axis_reflow",
         "varfont/instances_in_order",
         "varfont/unsupported_axes",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -9,6 +9,11 @@ PROFILE = {
         #
         "alt_caron",
         "cjk_chws_feature",
+        "designspace_has_consistent_codepoints",  # < TypeNetwork doesn’t check designspace files.
+        "designspace_has_consistent_glyphset",  #   <
+        "designspace_has_consistent_groups",  #     <
+        "designspace_has_default_master",  #        <
+        "designspace_has_sources",  #               <
         "family/single_directory",  # Sometimes we want to run the profile on multiple fonts.
         "fontbakery_version",
         "math_signs_width",  # It really depends on the design and the intended use to make math symbols the same width.
@@ -37,11 +42,6 @@ PROFILE = {
         "cjk_not_enough_glyphs",
         "color_cpal_brightness",
         "colorfont_tables",
-        "designspace_has_consistent_codepoints",
-        "designspace_has_consistent_glyphset",
-        "designspace_has_consistent_groups",
-        "designspace_has_default_master",
-        "designspace_has_sources",
         "empty_glyph_on_gid1_for_colrv0",
         "file_size",
         "fontdata_namecheck",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -9,17 +9,26 @@ PROFILE = {
         #
         "alt_caron",
         "caps_vertically_centered",  # Disabled: issue #4274
+        "cmap/format_12",
         "cjk_chws_feature",
+        "cjk_not_enough_glyphs",
+        "color_cpal_brightness",  # Color fonts check.
+        "colorfont_tables",  # Color fonts check.
         "designspace_has_consistent_codepoints",  # < TypeNetwork doesn’t check designspace files.
         "designspace_has_consistent_glyphset",  #   <
         "designspace_has_consistent_groups",  #     <
         "designspace_has_default_master",  #        <
         "designspace_has_sources",  #               <
+        "empty_glyph_on_gid1_for_colrv0",  # Color fonts check.
         "family/single_directory",  # Sometimes we want to run the profile on multiple fonts.
+        "file_size",
+        "fontval",  # Temporarily disabled
         "fontbakery_version",
+        "hinting_impact",
         "math_signs_width",  # It really depends on the design and the intended use to make math symbols the same width.
         "name/no_copyright_on_description",
         "os2_metrics_match_hhea",  # Removed in favor of new vmetrics check
+        "render_own_name",
         "STAT_strings",  # replaced by adobefonts/STAT_strings
         "superfamily/list",
         "ufolint",  #                             < TypeNetwork doesn’t check .ufo files.
@@ -27,45 +36,12 @@ PROFILE = {
         "ufo_recommended_fields",  #              <
         "ufo_required_fields",  #                 <
         "ufo_unnecessary_fields",  #              <
+        "vtt_volt_data",  # Very similar to 'vttclean' check, it may be a good idea to merge them.
+        "varfont/unsupported_axes",  # Despite discouraging its use, TN accepts fonts with ital axis.
     ],
     "pending_review": [
-        "opentype/cff_ascii_strings",
-        "opentype/postscript_name",
-        "opentype/varfont/family_axis_ranges",
-        "opentype/weight_class_fvar",
-        #
-        "googlefonts/gasp",
-        "googlefonts/glyphsets/shape_languages",
-        "googlefonts/metadata/primary_script",
-        "googlefonts/metadata/unreachable_subsetting",
-        "googlefonts/metadata/valid_nameid25",  # Previously this one had been marked as "temporarily excluded".
-        "googlefonts/negative_advance_width",
-        "googlefonts/STAT/axis_order",
-        #
-        "case_mapping",
-        "cmap/format_12",
-        "cjk_not_enough_glyphs",
-        "color_cpal_brightness",
-        "colorfont_tables",
-        "empty_glyph_on_gid1_for_colrv0",
-        "file_size",
-        "fontdata_namecheck",
-        "fontval",  # Temporarily disabled
-        "gsub/smallcaps_before_ligatures",
-        "hinting_impact",
-        "integer_ppem_if_hinted",
-        "legacy_accents",
-        "name/char_restrictions",
-        "no_debugging_tables",
+        "name/char_restrictions",  # This was originally called name/ascii_only_entries. Please review https://github.com/fonttools/fontbakery/pull/4869
         "overlapping_path_segments",
-        "render_own_name",
-        "tabular_kerning",
-        "typoascender_exceeds_Agrave",
-        "typographic_family_name",
-        "varfont/duplexed_axis_reflow",
-        "varfont/instances_in_order",
-        "varfont/unsupported_axes",
-        "vtt_volt_data",  # Very similar to 'vttclean' check, it may be a good idea to merge them.
     ],
     "sections": {
         "Type Network": [
@@ -96,8 +72,10 @@ PROFILE = {
         ],
         "Google Fonts": [
             "googlefonts/family/equal_codepoint_coverage",
+            # "googlefonts/negative_advance_width",  # See https://github.com/fonttools/fontbakery/pull/1727
             "googlefonts/varfont/bold_wght_coord",
             "googlefonts/varfont/duplicate_instance_names",
+            "googlefonts/STAT/axis_order",
         ],
         "Outline Checks": [
             "outline_alignment_miss",
@@ -107,7 +85,7 @@ PROFILE = {
             "outline_short_segments",
         ],
         "Shaping Checks": [
-            "dotted_circle",  # This one is included, but it would be good to be reviewed.
+            "dotted_circle",
             "soft_dotted",
         ],
     },

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -18,8 +18,6 @@ PROFILE = {
         "superfamily/list",
     ],
     "pending_review": [
-        "typenetwork/fstype",  # DEPRECATED: if not really needed anymore, it would be good to delete it from the repo.
-        #
         "opentype/cff_ascii_strings",
         "opentype/postscript_name",
         "opentype/varfont/family_axis_ranges",

--- a/Lib/fontbakery/profiles/typenetwork.py
+++ b/Lib/fontbakery/profiles/typenetwork.py
@@ -8,6 +8,7 @@ PROFILE = {
         "opentype/vendor_id",
         #
         "alt_caron",
+        "caps_vertically_centered",  # Disabled: issue #4274
         "cjk_chws_feature",
         "designspace_has_consistent_codepoints",  # < TypeNetwork doesn’t check designspace files.
         "designspace_has_consistent_glyphset",  #   <
@@ -41,7 +42,6 @@ PROFILE = {
         "googlefonts/negative_advance_width",
         "googlefonts/STAT/axis_order",
         #
-        "caps_vertically_centered",
         "case_mapping",
         "cmap/format_12",
         "cjk_not_enough_glyphs",

--- a/tests/test_checks_typenetwork.py
+++ b/tests/test_checks_typenetwork.py
@@ -1,14 +1,14 @@
-from fontTools.ttLib import TTFont
+# from fontTools.ttLib import TTFont
+#
+# from fontbakery.status import ERROR, FAIL, WARN, INFO, PASS, SKIP
+# from fontbakery.codetesting import (
+#    assert_results_contain,
+#    assert_PASS,
+#    TEST_FILE,
+#    CheckTester,
+# )
 
-from fontbakery.status import ERROR, FAIL, WARN, INFO, PASS, SKIP
-from fontbakery.codetesting import (
-    assert_results_contain,
-    assert_PASS,
-    TEST_FILE,
-    CheckTester,
-)
-
-check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
+# check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
 
 
 # ========= TODO: Implement code-test: ============
@@ -24,14 +24,7 @@ check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
 
 
 # ========= TODO: Implement code-test: ============
-#  font_is_centered_vertically
-
-
-# ========= TODO: Implement code-test: ============
-#  typenetwork/tnum_horizontal_metrics
-#  """Tabular figures need to have the same metrics in all styles in order
-#     to allow tables to be set with proper typographic control, but to maintain
-#     the placement of decimals and numeric columns between rows."""
+#  typenetwork/font_is_centered_vertically
 
 
 # ========= TODO: Implement code-test: ============
@@ -45,12 +38,12 @@ check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
 
 
 # ========= TODO: Implement code-test: ============
-#  family/valid_underline
+#  typenetwork/family/valid_underline
 #  """If underline thickness is not set nothing gets rendered on Figma."""
 
 
 # ========= TODO: Implement code-test: ============
-#  family/valid_strikeout
+#  typenetwork/family/valid_strikeout
 #  """If strikeout size is not set, nothing gets rendered on Figma."""
 
 
@@ -60,14 +53,14 @@ check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
 
 
 # ========= TODO: Implement code-test: ============
-#  PUA_encoded_glyphs
+#  typenetwork/PUA_encoded_glyphs
 #  """Since the use of PUA encoded glyphs is not frequent,
 #     we want to WARN when a font can be a bad use of it,
 #     like to encode small caps glyphs."""
 
 
 # ========= TODO: Implement code-test: ============
-#  marks_width
+#  typenetwork/marks_width
 #  """To avoid incorrect overlappings when typing, glyphs that are spacing marks
 #     must have width, on the other hand, combining marks should be 0 width."""
 
@@ -79,14 +72,14 @@ check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
 
 
 # ========= TODO: Implement code-test: ============
-#  varfont/axes_have_variation
+#  typenetwork/varfont/axes_have_variation
 #  """Axes on a variable font must have variation. In other words min and max values
 #     need to be different. It’s common to find fonts with unnecesary axes
 #     added like `ital`."""
 
 
 # ========= TODO: Implement code-test: ============
-#  varfont/fvar_axes_order
+#  typenetwork/varfont/fvar_axes_order
 #  """If a font doesn’t have a STAT table, instances get sorted better on Adobe Apps
 #     when fvar axes follow a specific order: 'opsz', 'wdth', 'wght','ital', 'slnt'.
 #     **Note:** We should deprecate this check since STAT is a required table."""

--- a/tests/test_checks_typenetwork.py
+++ b/tests/test_checks_typenetwork.py
@@ -11,24 +11,6 @@ from fontbakery.codetesting import (
 check_statuses = (ERROR, FAIL, WARN, INFO, PASS, SKIP)
 
 
-def test_check_fstype():
-    """Checking OS/2 fsType"""
-    check = CheckTester("typenetwork/fstype")
-
-    ttFont = TTFont(TEST_FILE("cabin/Cabin-Regular.ttf"))
-    for value in [0, 1, 2, 4, 8, 0x0100, 0x0200]:
-        ttFont["OS/2"].fsType = value
-        if value == 4:
-            assert_PASS(check(ttFont), "with a good font.")
-        else:
-            assert_results_contain(
-                check(ttFont),
-                WARN,
-                "no-preview-print",
-                "with a bad fstype value.",
-            )
-
-
 # ========= TODO: Implement code-test: ============
 #  typenetwork/glyph_coverage
 #  """Type Network expects that fonts in its catalog support at least the


### PR DESCRIPTION
Followup to #4878 

@guidoferreyra, I'm refactoring your update into smaller documented commits, so that others can better understand it at a quick glance.

I've also fixed the conflict, given that your changes were made against an older pre-release (v0.13.0a0) and we had additional checks implemented since then. Those will remain for a while under TN's "pending_review" (until you take a look at them as well).

I've kept a copy of your original submission at this branch, for reference: https://github.com/felipesanches/fontbakery/tree/tn-update-2024-10-31-original-submission