### PR TITLE
googlefonts/fvar_instances: Skip for fonts that have a MORF axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **ufo_unnecessary_fields** (.ufo files)
 
 ### Changes to existing checks
+### On the Google Fonts profile
+  - **[googlefonts/fvar_instances]:** Skip if font has MORF axis. We allow designers to define their own custom fvar instances if the font has a Morph axis. They spend a significant amount of time drawing custom shapes for this axis so it is the right call imo. (PR #4880)
+
 ### On the TypeNetwork profile
   - **[typenetwork/usweightclass]:** Fix weightclass check. (PR #4878)
 

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/varfont.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/varfont.py
@@ -160,10 +160,13 @@ def check_stat(ttFont, expected_font_names):
 
 @check(
     id="googlefonts/fvar_instances",
-    conditions=["is_variable_font"],
+    conditions=["is_variable_font", "not has_morf_axis"],
     rationale="""
         Check a font's fvar instance coordinates comply with our guidelines:
         https://googlefonts.github.io/gf-guide/variable.html#fvar-instances
+
+        This check is skipped for fonts that have a Morph (MORF) axis
+        since we allow users to define their own custom instances.
     """,
     proposal="https://github.com/fonttools/fontbakery/pull/3800",
 )

--- a/Lib/fontbakery/testable.py
+++ b/Lib/fontbakery/testable.py
@@ -167,6 +167,10 @@ class Font(Testable):
         return "wdth" in self.axes_by_tag
 
     @cached_property
+    def has_morf_axis(self):
+        return "MORF" in self.axes_by_tag
+
+    @cached_property
     def family_directory(self):
         """Get the path of font project directory."""
         return os.path.dirname(self.file) or "."

--- a/tests/test_checks_googlefonts.py
+++ b/tests/test_checks_googlefonts.py
@@ -3421,6 +3421,15 @@ def test_check_varfont_instance_names(vf_ttFont):
         "bad-fvar-instances",
         "with a variable font which does not have correct instance names.",
     )
+    # Let's see if the check is skipped if a font contains a MORF axis.
+    # We allow fonts with a MORF axis to have custom fvar instances.
+    from fontTools.ttLib.tables._f_v_a_r import Axis
+
+    vf_ttFont3 = copy(vf_ttFont)
+    morf_axis = Axis()
+    morf_axis.axisTag = "MORF"
+    vf_ttFont3["fvar"].axes.append(morf_axis)
+    assert_SKIP(check(vf_ttFont3))
 
 
 def test_check_varfont_duplicate_instance_names(vf_ttFont):


### PR DESCRIPTION
## Description

We allow designers to define their own custom fvar instances if the font has a Morph axis. They spend a significant amount of time drawing custom shapes for this axis so it is the right call imo.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

