### PR TITLE
googlefonts/font_names: raise warn for families with MORF axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-##  Upcoming release: 0.13.0 (a5?) (2024-Nov-??)
+##  Upcoming release: 0.13.0 (a5?) (2024-Nov-08)
   - ...
 
 
-##  0.13.0a4 (2024-Nov-01)
+##  0.13.0a4 (2024-Nov-05)
 ### Noteworthy release notes
   - Thanks Guido Ferreyra for updating the TypeNetwork profile based on its "pending_review" list of recent checks that had been added since his last review (summary of changes listed below). **Other profile owners should consider doing the same.** (PR #4878)
 
@@ -57,6 +57,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 ### On the Google Fonts profile
   - **[googlefonts/fvar_instances]:** Skip if font has MORF axis. We allow designers to define their own custom fvar instances if the font has a Morph axis. They spend a significant amount of time drawing custom shapes for this axis so it is the right call imo. (PR #4880)
+  - **[googlefonts/font_names]:** Raise WARN for families with MORF axis. (PR #4881)
 
 ### On the TypeNetwork profile
   - **[typenetwork/usweightclass]:** Fix weightclass check. (PR #4878)

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/name.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/name.py
@@ -116,6 +116,15 @@ def check_name_familyname_first_char(ttFont):
 )
 def check_font_names(ttFont, ttFonts):
     """Check font names are correct"""
+    if "fvar" in ttFont and "MORF" in [a.axisTag for a in ttFont["fvar"].axes]:
+        yield WARN, Message(
+            "morf-axis",
+            "Font has a Morph axis. This check only works on fonts that "
+            "have a wght axis. Since users can define their own stylenames "
+            "for Morph families, please manually check that the family works "
+            "on major platforms. You can use Agu Display as a reference.",
+        )
+        return
     expected_names = expected_font_names(ttFont, ttFonts)
 
     def style_names(nametable):


### PR DESCRIPTION
## Description

If a family contains a Morph axis, it most likely doesn't have a default stylename that conforms to our specification since our spec assumes every font will have a weight axis, or at least a Regular style.

Imo it is impossible to determine what the stylename will be since the designer can choose anything so it's best we just skip the check. However, instead of skipping, I feel it's better to raise a warn and inform the user that the font contains a Morph axis and to provide an example font.


## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

