### PR TITLE
googlefonts/axes_match: skip if remote_style is static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the Universal Profile
   - **[kerning_for_non_ligated_sequences]**: "Is there kerning info for non-ligated sequences?" (issue #2954 / https://github.com/simoncozens/fontspector/commit/eaa52447ddc4a42e26b6430841a43026870d8a48)
 
+### Changes to existing checks
+### On the Google Fonts profile
+  - **[googlefonts/axes_match]:** Skip if remote_style is static
+
 
 ##  0.13.0a6 (2024-Dec-03)
 ### Noteworthy code-changes

--- a/Lib/fontbakery/checks/vendorspecific/googlefonts/axes_match.py
+++ b/Lib/fontbakery/checks/vendorspecific/googlefonts/axes_match.py
@@ -1,4 +1,4 @@
-from fontbakery.prelude import FAIL, PASS, Message, check
+from fontbakery.prelude import SKIP, FAIL, PASS, Message, check
 
 
 @check(
@@ -11,6 +11,9 @@ from fontbakery.prelude import FAIL, PASS, Message, check
 )
 def check_axes_match(ttFont, remote_style):
     """Check if the axes match between the font and the Google Fonts version."""
+    if "fvar" not in remote_style:
+        yield SKIP, "Remote style is a static font."
+        return
     remote_axes = {
         a.axisTag: (a.minValue, a.maxValue) for a in remote_style["fvar"].axes
     }


### PR DESCRIPTION
## Description

Test shouldn't run if the family served on Google Fonts is static.


## Checklist
- [X] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

