### PR TITLE
[smallcaps_before_ligatures] should not have is_ttf condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A more detailed list of changes is available in the corresponding milestones for
   - **[kerning_for_non_ligated_sequences]**: "Is there kerning info for non-ligated sequences?" (issue #2954 / https://github.com/simoncozens/fontspector/commit/eaa52447ddc4a42e26b6430841a43026870d8a48)
 
 ### Changes to existing checks
+### On the Universal profile
+  - **[smallcaps_before_ligatures]:** This check works just fine on OTFs, no need for `conditions=["is_ttf"]` (issue #4920)
+
 ### On the Google Fonts profile
   - **[googlefonts/axes_match]:** Skip if remote_style is static
 

--- a/Lib/fontbakery/checks/smallcaps_before_ligatures.py
+++ b/Lib/fontbakery/checks/smallcaps_before_ligatures.py
@@ -16,7 +16,6 @@ from fontbakery.prelude import PASS, FAIL, SKIP, Message, check
         This check attempts to detect this kind of mistake.
     """,
     proposal="https://github.com/fonttools/fontbakery/issues/3020",
-    conditions=["is_ttf"],
 )
 def check_smallcaps_before_ligatures(ttFont):
     """


### PR DESCRIPTION
This check works just fine on OTFs, no need for `conditions=["is_ttf"]`.

* **smallcaps_before_ligatures**
* On the `Universal` profile.

(issue #4920)