### PR TITLE
Implemented a backwards compatibility feature for legacy check-IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Noteworthy code-changes
   - Created a dictionary at `Lib/fontbakery/legacy_checkids.py` that documents the renaming of checks-IDs that is happenning between versions v0.12.10 and v0.13.0 (PR #4929)
 
-  This file contains a translation map that can be useful:
-  - to be read directly by humans
-  - to generate documentation
-  - to implement a backwards compatibility mechanism
+  - This file contains a translation map that can be useful to be read directly by humans and it is also used to implement a backwards compatibility mechanism to accept the old IDs.
+
+  - All reporters are now listing which legacy check-IDs were used on the --check-id and --exclude-checkid options and instructing the users to update to the new naming scheme, because the old ones will be permanently deprecated in the next major release. (issue #4942)
 
 ### New checks
 #### Added to the Universal profile

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -77,6 +77,29 @@ class GHMarkdownReporter(HTMLReporter):
                             other_checks[key] = []
                         other_checks[key].append(check)
 
+                    if self.legacy_checkid_references:
+                        references = "\n - ".join(self.legacy_checkid_references)
+                        deprecation_warning = (
+                            "By late-December 2024, FontBakery version 0.13.0"
+                            " introduced a new naming scheme for the check-IDs.\n"
+                            "\n"
+                            "Fontbakery detected usage of old IDs and performed an"
+                            " automatic backwards-compatibility translation for you.\n"
+                            "This automatic translation will be deprecated in the next"
+                            " major release.\n"
+                            "\n"
+                            "Please start using the new check-IDs as documented at\n"
+                            "https://github.com/fonttools/fontbakery/blob/"
+                            "83db7cc2a6ad58585ddec9397306e0420843edb1/Lib/"
+                            "fontbakery/legacy_checkids.py\n"
+                            "\n"
+                            "The following legacy check-IDs were detected:\n"
+                            f" - {references}\n"
+                            "\n"
+                        )
+                    else:
+                        deprecation_warning = None
+
         # Sort them by log-level results:
         ordering = ["ERROR", "FATAL", "FAIL", "WARN", "INFO", "PASS", "SKIP"]
         for check_group in [fatal_checks, experimental_checks, other_checks]:
@@ -94,4 +117,5 @@ class GHMarkdownReporter(HTMLReporter):
             other_checks=other_checks,
             succinct=self.succinct,
             total=num_checks,
+            deprecation_warning=deprecation_warning,
         )

--- a/Lib/fontbakery/reporters/html.py
+++ b/Lib/fontbakery/reporters/html.py
@@ -110,6 +110,28 @@ class HTMLReporter(SerializeReporter):
                 (e for e in section["result"].elements() if e != "PASS"),
                 key=LOGLEVELS.index,
             )
+        if self.legacy_checkid_references:
+            deprecation_warning = (
+                "By late-December 2024, FontBakery version 0.13.0"
+                " introduced a new naming scheme for the check-IDs.<br>"
+                "<br>"
+                "Fontbakery detected usage of old IDs and performed an"
+                " automatic backwards-compatibility translation for you.<br>"
+                "This automatic translation will be deprecated in the next"
+                " major release.<br>"
+                "<br>"
+                "Please start using the new check-IDs as documented at"
+                " <a href='https://github.com/fonttools/fontbakery/blob/"
+                "83db7cc2a6ad58585ddec9397306e0420843edb1/Lib/"
+                "fontbakery/legacy_checkids.py'>"
+                "/Lib/fontbakery/legacy_checkids.py</a><br>"
+                "<br>"
+                "The following legacy check-IDs were detected:<br>"
+                f" - {'<br> - '.join(self.legacy_checkid_references)}<br>"
+                "<br>"
+            )
+        else:
+            deprecation_warning = None
 
         return self.template_engine().render(
             sections=data["sections"],
@@ -118,4 +140,5 @@ class HTMLReporter(SerializeReporter):
             total=total,
             summary={k: data["result"][k] for k in LOGLEVELS},
             succinct=self.succinct,
+            deprecation_warning=deprecation_warning,
         )

--- a/Lib/fontbakery/reporters/templates/html/main.html
+++ b/Lib/fontbakery/reporters/templates/html/main.html
@@ -19,6 +19,10 @@
 
     <main>
         {% include "top.html" %}
+        {% if deprecation_warning %}
+        <h3>DEPRECATION WARNING</h3>
+        <p>{{deprecation_warning|safe}}</p>
+        {% endif %}
         {% include "summary_table.html" %}
         {% include "summary_notes.html" %}
         {% for section in sections %}

--- a/Lib/fontbakery/reporters/templates/markdown/main.markdown
+++ b/Lib/fontbakery/reporters/templates/markdown/main.markdown
@@ -2,6 +2,11 @@
 
 fontbakery version: {{fb_version}}
 
+{% if deprecation_warning %}
+### DEPRECATION WARNING
+{{deprecation_warning}}
+{% endif %}
+
 {% if fatal_checks %}
 ## Checks with FATAL results
 

--- a/Lib/fontbakery/reporters/terminal.py
+++ b/Lib/fontbakery/reporters/terminal.py
@@ -197,6 +197,27 @@ class TerminalReporter(FontbakeryReporter):
             and self._counter[PASS.name] > 20
         ):
             self._console.print(CUPCAKE)
+        if self.legacy_checkid_references:
+            references = "\n - ".join(self.legacy_checkid_references)
+            self._console.print(
+                "[message-FATAL]DEPRECATION WARNING[/]:\n"
+                "By late-December 2024, FontBakery version 0.13.0 introduced a new"
+                " naming scheme for the check-IDs.\n"
+                "\n"
+                "Fontbakery detected usage of old IDs and performed an automatic"
+                " backwards-compatibility translation for you.\n"
+                "This automatic translation will be deprecated in the next"
+                " major release.\n"
+                "\n"
+                "Please start using the new check-IDs as documented at\n"
+                "https://github.com/fonttools/fontbakery/blob/"
+                "83db7cc2a6ad58585ddec9397306e0420843edb1/Lib/"
+                "fontbakery/legacy_checkids.py\n"
+                "\n"
+                "The following legacy check-IDs were detected:\n"
+                f" - {references}\n"
+                "\n"
+            )
         self._console.print("DONE!")
 
     def receive_result(self, checkresult: CheckResult):


### PR DESCRIPTION
All reporters are now listing which legacy check-IDs were used on the `--check-id` and `--exclude-checkid` options and instructing the users to update to the new naming scheme, because the old ones will be permanently deprecated in the next major release.

(issue #4942)