### PR TITLE
Add fontbakery-venv to gitignore to match the developer doc 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 htmlcov
 _version.py
 venv
+fontbakery-venv
 docs/_build
 .eggs
 .tox


### PR DESCRIPTION
## Description
Adds `fontbakery-venv` to git ignore to match what the developer docs recommend for the venv name

