### PR TITLE
check_base_has_width: use correct param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### Changes to existing checks
 ### On the Universal profile.
   - **[fontdata_namecheck]** Use api endpoint (issues #https://github.com/fonttools/fontbakery/issues/2719#issuecomment-2618877625)
+  - **[base_has_width]** Use `config` instead of `context` variable. (PR #4983)
 
 
 ##  0.13.1 (2025-Jan-17)

--- a/Lib/fontbakery/checks/base_has_width.py
+++ b/Lib/fontbakery/checks/base_has_width.py
@@ -23,7 +23,7 @@ def is_space(codepoint):
     proposal="https://github.com/fonttools/fontbakery/issues/4906",
     experimental="Since 2024/12/28",
 )
-def check_base_has_width(font, context):
+def check_base_has_width(font, config):
     """Check base characters have non-zero advance width."""
 
     reversed_cmap = {v: k for k, v in font.ttFont.getBestCmap().items()}
@@ -43,7 +43,7 @@ def check_base_has_width(font, context):
             problems.append(f"{gid} (U+{codepoint:04X})")
 
     if problems:
-        problems = bullet_list(context, problems)
+        problems = bullet_list(config, problems)
         yield FAIL, Message(
             "zero-width-bases",
             f"The following glyphs had zero advance width:\n{problems}",


### PR DESCRIPTION
## Description

CI is failing for Merriweather, https://github.com/google/fonts/pull/7886#issuecomment-2621455851:

```
ERROR Check base characters have non-zero advance width. [base_has_width](https://fontbakery.readthedocs.io/en/stable/fontbakery/checks/universal.html#base-has-width)
💥 ERROR
Failed with AttributeError: 'CheckRunContext' object has no attribute 'get'
```

The check is currently trying to pass a `context` variable into a bullet list, when it actually needs a `config` variable.


## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

