### PR TITLE
Fix raw error crashing HTML reporter, add types, and share error helper

### DIFF
--- a/Lib/fontbakery/message.py
+++ b/Lib/fontbakery/message.py
@@ -7,7 +7,9 @@ KEEP_ORIGINAL_MESSAGE = None
 class Message:
     """Status messages to be yielded by FontBakeryCheck"""
 
-    def __init__(self, code, message):
+    message: str
+
+    def __init__(self, code, message: str):
         """
         code: (string|number) a check internal, unique code to describe a
               specific failure condition. A short string is preferred, it

--- a/Lib/fontbakery/utils.py
+++ b/Lib/fontbakery/utils.py
@@ -16,6 +16,7 @@
 import os
 import subprocess
 import sys
+import traceback
 from typing import Optional
 from copy import deepcopy
 
@@ -860,3 +861,12 @@ def mark_glyphs(ttFont):
             if name in class_def and class_def[name] == 3:
                 marks.append(name)
     return marks
+
+
+def format_error(error: Exception) -> str:
+    """Detail an error with name and stack trace for serialisation."""
+
+    message = f"Failed with {type(error).__name__}: {error}\n```\n"
+    message += "".join(traceback.format_tb(error.__traceback__))
+    message += "\n```"
+    return message


### PR DESCRIPTION
## Description

There was one call site where we were accidentally passing a raw Exception as a message instead of a serialised summary, which was crashing the HTML reporter.

This commit corrects this by serialising at that site, adds more types to Message to automatically warn for this category of issue in the future, and pulls the stack trace formatting code out into a public function to provide more error details in more places.

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

