### PR TITLE
Update camelcased_familyname_exceptions.txt

### DIFF
--- a/Lib/fontbakery/data/googlefonts/camelcased_familyname_exceptions.txt
+++ b/Lib/fontbakery/data/googlefonts/camelcased_familyname_exceptions.txt
@@ -32,3 +32,4 @@ SignWriting # seen in "Noto Sans SignWriting"
 WindSong
 ADLaM
 YouTube # seen in "YouTube Sans" 
+UoqMunThenKhung


### PR DESCRIPTION
I am preparing to add `UoqMunThenKhung` (https://github.com/MoonlitOwen/ThenKhung) to Google Fonts, and am receiving a FAIL due to the use of a camelCase name. Submitting this PR to add it as an exception. Thanks!