### PR TITLE
[ligature_carets] Don't error if the font has no GDEF table

### DIFF
--- a/Lib/fontbakery/checks/ligature_carets.py
+++ b/Lib/fontbakery/checks/ligature_carets.py
@@ -47,7 +47,7 @@ def check_ligature_carets(config, ttFont, ligature_glyphs):
         yield WARN, Message(
             "lacks-caret-pos-gdef",
             "This font lacks caret position values"
-            " for ligature glyphs because it has not GDEF table.",
+            " for ligature glyphs because it doesn't have a GDEF table.",
         )
     else:
         lig_caret_list = ttFont["GDEF"].table.LigCaretList

--- a/Lib/fontbakery/checks/ligature_carets.py
+++ b/Lib/fontbakery/checks/ligature_carets.py
@@ -43,6 +43,12 @@ def check_ligature_carets(config, ttFont, ligature_glyphs):
     """Are there caret positions declared for every ligature?"""
     if len(ligature_glyphs) == 0:
         yield SKIP, Message("no-ligatures", "No ligature glyphs found.")
+    elif "GDEF" not in ttFont:
+        yield WARN, Message(
+            "lacks-caret-pos-gdef",
+            "This font lacks caret position values"
+            " for ligature glyphs because it has not GDEF table.",
+        )
     else:
         lig_caret_list = ttFont["GDEF"].table.LigCaretList
         if lig_caret_list is None:


### PR DESCRIPTION
The ligature_carets check threw an error when the font has no GDEF table. This PR makes it return a WARN in that case.
