### PR TITLE
fix `base_has_width` and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ### On the Universal profile
   - **[unwanted_tables]:** Remove checking for 'prop' because it is an AAT table. (issue #4989)
+  - **[base_has_width]:** Examine non-mark glyphs rather than mark glyphs; ignore PUA. (issue #5007)
 
 
 ##  0.13.2 (2025-Feb-03)

--- a/Lib/fontbakery/checks/base_has_width.py
+++ b/Lib/fontbakery/checks/base_has_width.py
@@ -5,14 +5,20 @@ from fontbakery.utils import bullet_list, mark_glyphs
 
 
 def is_space(codepoint):
-    return unicodedata.category(chr(codepoint)) in [
-        "Zs",  # Space Separator
-        "Zl",  # Line Separator
-        "Zp",  # Paragraph Separator
-        "Cf",  # Format
-        "Mn",  # Nonspacing Mark
-        "Cc",  # Control
-    ]
+    return (
+        unicodedata.category(chr(codepoint))
+        in [
+            "Zs",  # Space Separator
+            "Zl",  # Line Separator
+            "Zp",  # Paragraph Separator
+            "Cf",  # Format
+            "Mn",  # Nonspacing Mark
+            "Cc",  # Control
+        ]
+        or 0xE000 <= codepoint <= 0xF8FF
+        or 0xF0000 <= codepoint <= 0xFFFFD
+        or 0x100000 <= codepoint <= 0x10FFFD
+    )
 
 
 @check(
@@ -36,7 +42,7 @@ def check_base_has_width(font, config):
         if codepoint == 0 or codepoint is None:
             continue
 
-        if advance == 0 and not gid not in mark_glyphs(font.ttFont):
+        if advance == 0 and gid not in mark_glyphs(font.ttFont):
             if is_space(codepoint):
                 continue
 

--- a/tests/test_checks_base_has_width.py
+++ b/tests/test_checks_base_has_width.py
@@ -1,0 +1,48 @@
+from io import BytesIO
+from fontTools.ttLib import TTFont
+
+from conftest import check_id
+from fontbakery.status import FAIL
+from fontbakery.codetesting import (
+    assert_PASS,
+    assert_results_contain,
+    TEST_FILE,
+)
+
+
+def get_test_font():
+    import defcon
+    import ufo2ft
+
+    test_ufo = defcon.Font(TEST_FILE("test.ufo"))
+    # Add a PUA character that has no width
+    glyph = test_ufo.newGlyph("uniF176")
+    glyph.unicode = 0xF176
+    test_ttf = ufo2ft.compileTTF(test_ufo)
+
+    # Make the CheckTester class happy... :-P
+    stream = BytesIO()
+    test_ttf.save(stream)
+    stream.seek(0)
+    test_ttf = TTFont(stream)
+    test_ttf.reader.file.name = "in-memory-data.ttf"
+    return test_ttf
+
+
+@check_id("base_has_width")
+def test_check_base_has_width(check):
+    """Do some base characters have zero width?"""
+
+    ttfont = get_test_font()
+
+    assert_PASS(check(ttfont), "if acute has width...")
+
+    ttfont["hmtx"].metrics["A"] = (0, 0)
+
+    message = assert_results_contain(
+        check(ttfont),
+        FAIL,
+        "zero-width-bases",
+        "following glyphs had zero advance width",
+    )
+    assert "U+0041" in message


### PR DESCRIPTION
## Description
Fixes concerns raised in #5007 

Update `checks/base_has_width.py` to:
- Ignore PUA characters
- Reverse the mark class test so that it:
  - Ignores glyphs that _are_ in GDEF mark class
  - Checks glyphs that are _not_ in the GDEF mark class 

and add `tests/test_checks_base_has_width.py` to verify correct behavior

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

