### PR TITLE
Fix typographic family name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-##  Upcoming release: 0.13.3 (2025-Feb-??)
+##  Upcoming release: 0.13.3 (2025-Apr-??)
 
 ### Migration of checks
 #### Moved from Universal to OpenType profile
@@ -14,7 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### On the Universal profile
   - **[unwanted_tables]:** Remove checking for 'prop' because it is an AAT table. (issue #4989)
   - **[base_has_width]:** Examine non-mark glyphs rather than mark glyphs; ignore PUA. (issue #5007)
-  - **[typographic_family_name]:** Fix for support families with RIBBI and non-RIBBI styles.
+  - **[typographic_family_name]:** Fix for support families with RIBBI and non-RIBBI styles. (PR #5012)
 
 
 ##  0.13.2 (2025-Feb-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
 ##  Upcoming release: 0.13.3 (2025-Feb-??)
+
 ### Migration of checks
 #### Moved from Universal to OpenType profile
   - **[[opentype/unwanted_aat_tables]]:** AAT is as legitimate as OpenType and Apple ships and actively develop AAT fonts. Such check belongs to the OpenYype profile instead of the Universal profile. (issue #4991)
@@ -13,6 +14,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ### On the Universal profile
   - **[unwanted_tables]:** Remove checking for 'prop' because it is an AAT table. (issue #4989)
   - **[base_has_width]:** Examine non-mark glyphs rather than mark glyphs; ignore PUA. (issue #5007)
+  - **[typographic_family_name]:** Fix for support families with RIBBI and non-RIBBI styles.
 
 
 ##  0.13.2 (2025-Feb-03)

--- a/Lib/fontbakery/checks/typographic_family_name.py
+++ b/Lib/fontbakery/checks/typographic_family_name.py
@@ -15,9 +15,9 @@ def check_typographic_family_name(ttFonts):
     for ttFont in ttFonts:
         name_record = ttFont["name"].getName(16, 3, 1, 0x0409)
         if name_record is None:
-            values.add("<no value>")
-        else:
-            values.add(name_record.toUnicode())
+            name_record = ttFont["name"].getName(1, 3, 1, 0x0409)
+
+        values.add(name_record.toUnicode())
     if len(values) != 1:
         yield FAIL, (
             f"Name ID 16 (Typographic Family name) is not consistent "

--- a/Lib/fontbakery/checks/typographic_family_name.py
+++ b/Lib/fontbakery/checks/typographic_family_name.py
@@ -22,5 +22,5 @@ def check_typographic_family_name(ttFonts):
         yield FAIL, Message(
             "incosistent-family-name",
             f"Name ID 16 (Typographic Family name) is not consistent "
-            f"across fonts. Values found: {sorted(values)}"
+            f"across fonts. Values found: {sorted(values)}",
         )

--- a/Lib/fontbakery/checks/typographic_family_name.py
+++ b/Lib/fontbakery/checks/typographic_family_name.py
@@ -1,4 +1,4 @@
-from fontbakery.prelude import check, FAIL
+from fontbakery.prelude import check, FAIL, Message
 
 
 @check(
@@ -19,7 +19,8 @@ def check_typographic_family_name(ttFonts):
 
         values.add(name_record.toUnicode())
     if len(values) != 1:
-        yield FAIL, (
+        yield FAIL, Message(
+            "incosistent-family-name",
             f"Name ID 16 (Typographic Family name) is not consistent "
             f"across fonts. Values found: {sorted(values)}"
         )

--- a/tests/test_checks_name.py
+++ b/tests/test_checks_name.py
@@ -93,9 +93,7 @@ def test_check_typographic_family_name(check, cabin_ttFonts, montserrat_ttFonts)
     assert_PASS(check(family), "with a good family...")
 
     assert_results_contain(
-        check([cabin_ttFonts, montserrat_ttFonts]),
-        FAIL,
-        "incosistent-family-name"
+        check([cabin_ttFonts, montserrat_ttFonts]), FAIL, "incosistent-family-name"
     )
 
 

--- a/tests/test_checks_name.py
+++ b/tests/test_checks_name.py
@@ -18,6 +18,46 @@ def test_ttFont():
     return TTFont(TEST_FILE("selawik/Selawik-fvar-test-VTT.ttf"), lazy=True)
 
 
+@pytest.fixture
+def montserrat_ttFonts():
+    paths = [
+        TEST_FILE("montserrat/Montserrat-Black.ttf"),
+        TEST_FILE("montserrat/Montserrat-BlackItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-Bold.ttf"),
+        TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-ExtraBold.ttf"),
+        TEST_FILE("montserrat/Montserrat-ExtraBoldItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"),
+        TEST_FILE("montserrat/Montserrat-ExtraLightItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-Italic.ttf"),
+        TEST_FILE("montserrat/Montserrat-Light.ttf"),
+        TEST_FILE("montserrat/Montserrat-LightItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-Medium.ttf"),
+        TEST_FILE("montserrat/Montserrat-MediumItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-Regular.ttf"),
+        TEST_FILE("montserrat/Montserrat-SemiBold.ttf"),
+        TEST_FILE("montserrat/Montserrat-SemiBoldItalic.ttf"),
+        TEST_FILE("montserrat/Montserrat-Thin.ttf"),
+        TEST_FILE("montserrat/Montserrat-ThinItalic.ttf"),
+    ]
+    return [TTFont(path) for path in paths]
+
+
+@pytest.fixture
+def cabin_ttFonts():
+    paths = [
+        TEST_FILE("cabin/Cabin-BoldItalic.ttf"),
+        TEST_FILE("cabin/Cabin-Bold.ttf"),
+        TEST_FILE("cabin/Cabin-Italic.ttf"),
+        TEST_FILE("cabin/Cabin-MediumItalic.ttf"),
+        TEST_FILE("cabin/Cabin-Medium.ttf"),
+        TEST_FILE("cabin/Cabin-Regular.ttf"),
+        TEST_FILE("cabin/Cabin-SemiBoldItalic.ttf"),
+        TEST_FILE("cabin/Cabin-SemiBold.ttf"),
+    ]
+    return [TTFont(path) for path in paths]
+
+
 @check_id("name_id_1")
 def test_check_name_id_1(check, test_ttFont):
     """Font has a name with ID 1."""
@@ -46,15 +86,17 @@ def test_check_name_length_req(check, test_ttFont):
 
 
 @check_id("typographic_family_name")
-def test_check_typographic_family_name(check, test_ttFont):
+def test_check_typographic_family_name(check, cabin_ttFonts, montserrat_ttFonts):
     """Typographic Family name consistency."""
 
-    family = [
-        test_ttFont,  # FIXME: This must be tested with more than a single font file!
-    ]
+    family = montserrat_ttFonts
     assert_PASS(check(family), "with a good family...")
 
-    # TODO: test a FAIL case
+    assert_results_contain(
+        check([cabin_ttFonts, montserrat_ttFonts]),
+        FAIL,
+        "incosistent-family-name"
+    )
 
 
 @check_id("name/char_restrictions")


### PR DESCRIPTION
## Description
When checking a typical family with RIBBI and non-RIBBI styles fonts can have or not ID 16. 
In the current state of the check, is ignoring this case adding the empty value to the list of family names.
This is creating a false positive in most of the families I check. From my point of view, the check should try to get ID 16 and if is not present get ID 1 and check if there is more than one.

    🔥 FAIL
    Name ID 16 (Typographic Family name) is not consistent across fonts. Values found: ['', 'MyFamily']

The test for this check was incomplete so I did an attempt to complete it, please take look and let me know if it’s good.

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

