### PR TITLE
Set a minimum requirement for the opentypespec dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
-##  Upcoming release: 0.13.3 (2025-Apr-??)
+##  Upcoming release: 0.13.4 (2025-May-?)
+  - ...
 
+
+##  0.13.3 (2025-Apr-06)
 ### Migration of checks
 #### Moved from Universal to OpenType profile
-  - **[[opentype/unwanted_aat_tables]]:** AAT is as legitimate as OpenType and Apple ships and actively develop AAT fonts. Such check belongs to the OpenYype profile instead of the Universal profile. (issue #4991)
+  - **[opentype/unwanted_aat_tables]:** AAT is as legitimate as OpenType and Apple ships and actively develop AAT fonts. Such check belongs to the OpenYype profile instead of the Universal profile. (issue #4991)
 
 ### Changes to existing checks
 ### On the OpenType profile
   - **[opentype/unwanted_aat_tables]:** EBSC is not an AAT table. (issue #4992)
+  - **[opentype/layout_valid_script_tags]:** Set a minimum requirement for the opentypespec dependency. To make sure 'sunu' script tag (for Sunuwar) is recognized as a valid tag. (issue #5014)
 
 ### On the Universal profile
   - **[unwanted_tables]:** Remove checking for 'prop' because it is an AAT table. (issue #4989)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ##  0.13.3 (2025-Apr-06)
 ### Migration of checks
 #### Moved from Universal to OpenType profile
-  - **[opentype/unwanted_aat_tables]:** AAT is as legitimate as OpenType and Apple ships and actively develop AAT fonts. Such check belongs to the OpenYype profile instead of the Universal profile. (issue #4991)
+  - **[opentype/unwanted_aat_tables]:** AAT is as legitimate as OpenType and Apple ships and actively develop AAT fonts. Such check belongs to the OpenType profile instead of the Universal profile. (issue #4991)
 
 ### Changes to existing checks
 ### On the OpenType profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "freetype-py < 2.4.0",  # see: https://github.com/fonttools/fontbakery/issues/4143
     "Jinja2 >= 3.0.0",  # issue #4717
     "munkres",
-    "opentypespec",
+    "opentypespec >= 1.9.2",  # recognize 'sunu' script tag for Sunuwar (fontbakery/issues/5014)
     "opentype-sanitizer >= 9.1.0, == 9.*",
     "packaging >= 14.5",  # VERSION_PATTERN was added on v14.5 (fontbakery/issues/4792)
     "pip-api",


### PR DESCRIPTION
To make sure 'sunu' script tag (for Sunuwar) is recognized as a valid tag on the 'opentype/layout_valid_script_tags' check.

(issue #5014)