### PR TITLE
[family_and_style_max_length] Modernize check

### DIFF
--- a/Lib/fontbakery/checks/name/family_and_style_max_length.py
+++ b/Lib/fontbakery/checks/name/family_and_style_max_length.py
@@ -29,7 +29,7 @@ def check_name_family_and_style_max_length(ttFont):
     checks = [
         [
             FAIL,
-            NameID.FULL_FONT_NAME,
+            NameID.FONT_FAMILY_NAME,
             32,
             (
                 "with the dropdown menu in old versions of Microsoft Word"


### PR DESCRIPTION
## Description
Relates to issue #2179, specifically later comments and testing, like https://github.com/fonttools/fontbakery/issues/2179#issuecomment-2675729457

Changes:
- [x] Change main static font check to consider NameID 1 (`FONT_FAMILY_NAME`) rather than NameID 4 (`FULL_FONT_NAME`)
- [ ] Consider removing test of NameID 6, or increasing to a much longer limit (I think it may be okay for these to be something like 64 or 128 characters?)
- [ ] Change VF check to test NameID 16 + STAT particles

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

## Process notes
Questions to answer
- [ ] Is the maximum acceptable length 32, or 31? The check tests for 32 or fewer, but I think it should be 31 or fewer.
- [ ] Does nameID 4 really matter? (No, not in my recent experience and testing.)
- [ ] Does a long nameID 6 really "cause issues with PostScript printers, especially on Mac platforms"? What is the basis for this check? Neither of the listed issues seem to say anything about this.

Test fonts probably needed
- [ ] static font with NameID 1 of 32 characters, and NameID 4 of 40 characters
- [ ] static font with NameID 1 of 31 characters, and NameID 4 of 40 characters
- [ ] variable font with no NameID 16, NameID 1 of 20 characters, long fvar names, and short STAT names
- [ ] variable font with NameID 16 of 20 characters, long fvar names, and short STAT names


