### PR TITLE
Fix test_checks_unique_glyphnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+## Upcoming release: 1.0.0 (2025-Jun-??)
 ### Bugfixes
+- fonttools==4.58.0 has been changed (PR #https://github.com/fonttools/fonttools/pull/3809/): It fixes duplicate names, therefore the test for the `unique_glyphnames`check was failing. (issue #5023)
 
-- fonttools==4.58.0 has been changed (PR #https://github.com/fonttools/fonttools/pull/3809/): It fixes duplicate names, therefore test_checks_unique_glyphnames failed. Fixed it. (issue #5023)
-
-##  1.0.0 (2025-May-07)
+## 1.0.0 (2025-May-07)
   - See also: https://github.com/fonttools/fontspector
 
 ### Migration of checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Below are the noteworthy changes from each release.
 A more detailed list of changes is available in the corresponding milestones for each release in the Github issue tracker (https://github.com/googlefonts/fontbakery/milestones?state=closed).
 
+### Bugfixes
+
+- fonttools==4.58.0 has been changed (PR #https://github.com/fonttools/fonttools/pull/3809/): It fixes duplicate names, therefore test_checks_unique_glyphnames failed. Fixed it. (issue #5023)
 
 ##  1.0.0 (2025-May-07)
   - See also: https://github.com/fonttools/fontspector

--- a/tests/test_checks_unique_glyphnames.py
+++ b/tests/test_checks_unique_glyphnames.py
@@ -26,13 +26,13 @@ def test_check_unique_glyphnames(check):
 
     # Load again, we changed the font directly.
     ttFont = TTFont(TEST_FILE("nunito/Nunito-Regular.ttf"))
-    ttFont.setGlyphOrder(glyph_names)
     # Just access the data to make fonttools generate it.
     ttFont["post"]  # pylint:disable=pointless-statement
     _file = io.BytesIO()
     _file.name = ttFont.reader.file.name
     ttFont.save(_file)
     ttFont = TTFont(_file)
+    ttFont.setGlyphOrder(glyph_names)
     message = assert_results_contain(check(ttFont), FAIL, "duplicated-glyph-names")
     assert "space" in message
 


### PR DESCRIPTION
## Description
Relates to issue #5023

I moved `ttFont.setGlyphOrder(glyph_names)` a few lines down, so that fonttools cannot fix the duplicate names.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

