### PR TITLE
Fix using old check ids in excluded checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ A more detailed list of changes is available in the corresponding milestones for
 ## Upcoming release: 1.0.1 (2025-Jun-??)
 ### Bugfixes
 - fonttools==4.58.0 has been changed (PR #https://github.com/fonttools/fonttools/pull/3809/): It fixes duplicate names, therefore the test for the `unique_glyphnames`check was failing. (issue #5023)
+- Fix passing legacy check ids to --exclude-checkid (PR #5032)
 
 ### On the opentype profile
 - **[check_monospace]:** Check CFF fonts as well: remove conditions "is_ttf" + remove "glyf" from required tables (issue #5030)

--- a/Lib/fontbakery/checkrunner.py
+++ b/Lib/fontbakery/checkrunner.py
@@ -238,6 +238,17 @@ class CheckRunner:
 
     @property
     def order(self) -> Tuple[Identity, ...]:
+        # map old excluded check ids to new ones
+        _exclude_checks = None
+        if self._exclude_checks:
+            _exclude_checks = []
+            for excluded in self._exclude_checks:
+                if excluded in old_to_new:
+                    self.legacy_checkid_references.add(excluded)
+                    _exclude_checks.append(old_to_new[excluded])
+                else:
+                    _exclude_checks.append(excluded)
+
         _order = []
         for section in self.profile.sections:
             for check in section.checks:
@@ -260,15 +271,13 @@ class CheckRunner:
                     if not selected_via_legacy_checkid and not selected_via_new_checkid:
                         continue
 
-                if self._exclude_checks:
-                    if any(excluded in check.id for excluded in self._exclude_checks):
+                if _exclude_checks:
+                    if any(excluded in check.id for excluded in _exclude_checks):
                         continue
 
                     if check.id in self.new_to_old:
                         for legacy in self.new_to_old[check.id]:
-                            if any(
-                                excluded in legacy for excluded in self._exclude_checks
-                            ):
+                            if any(excluded in legacy for excluded in _exclude_checks):
                                 self.legacy_checkid_references.add(legacy)
                                 continue
 

--- a/tests/test_external_profile.py
+++ b/tests/test_external_profile.py
@@ -96,3 +96,26 @@ def test_in_and_exclude_checks_default():
 
     checks = profile_checks(fakemodule, {"explicit_checks": ["opentype/unitsperem"]})
     assert checks == ["opentype/unitsperem"]
+
+
+def test_exclude_checks_old_ids():
+    from fontbakery.legacy_checkids import renaming_map
+
+    fakemodule = FakeModule()
+    setattr(
+        fakemodule,
+        "PROFILE",
+        {
+            "include_profiles": ["microsoft"],
+            "sections": {},
+        },
+    )
+
+    old = "com.microsoft/check/vendor_url"
+    new = renaming_map[old]
+
+    checks = profile_checks(fakemodule)
+    assert new in checks
+
+    checks = profile_checks(fakemodule, {"exclude_checks": [old]})
+    assert new not in checks


### PR DESCRIPTION


## Description
Passing old check ids to `--exclude-checkid` was broken since the old ids in exclude_checks were never mapped to new ones.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

