### PR TITLE
opentype/STAT/ital_axis misfires on static fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ A more detailed list of changes is available in the corresponding milestones for
 #### On the OpenType profile
   - **[opentype/monospace]**: Ensure check works with monospace OTF fonts (PR #5051)
 
+  - **[opentype/STAT/ital_axis]**: Skip check for fonts without STAT table (issue #4998)
+
 ## 1.1.0 (2025-Oct-02)
   - Replace deprecated `pkg_resources` by `importlib.resources` (issue #5028)
 

--- a/Lib/fontbakery/checks/opentype/STAT/ital_axis.py
+++ b/Lib/fontbakery/checks/opentype/STAT/ital_axis.py
@@ -22,7 +22,7 @@ def get_STAT_axis_value(ttFont, tag):
 
 def check_has_ital(font):
     if "STAT" not in font.ttFont:
-        yield FAIL, Message(
+        yield SKIP, Message(
             "no-stat",
             f"Font {font.file} has no STAT table",
         )


### PR DESCRIPTION
## Description
Fixes #4998

Many static fonts fail this test, reporting e.g. `🔥 FAIL Font DINish-Regular.ttf has no STAT table`. The rationale for the check is to make sure that when an ITAL axis is present, it is last in the STAT table. This check is not designed for fonts without a STAT table, so it should report absence of a STAT  table as a SKIP rather than a FAIL.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

