### PR TITLE
Fix PUA block range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
   - **[opentype/STAT/ital_axis]**: Skip check for fonts without STAT table (issue #4998)
 
+#### On the Noto Fonts profile
+  - **[notofonts/unicode_range_bits]**: Correctly detect PUA glyphs between 0xF0000 and 0xFF000
+
 ## 1.1.0 (2025-Oct-02)
   - Replace deprecated `pkg_resources` by `importlib.resources` (issue #5028)
 

--- a/Lib/fontbakery/constants.py
+++ b/Lib/fontbakery/constants.py
@@ -534,7 +534,7 @@ UNICODERANGE_DATA = [
     ],
     [(89, "Mathematical Alphanumeric Symbols", 0x1D400, 0x1D7FF)],
     [
-        (90, "Private Use (plane 15)", 0xFF000, 0xFFFFD),
+        (90, "Private Use (plane 15)", 0xF0000, 0xFFFFD),
         (90, "Private Use (plane 16)", 0x100000, 0x10FFFD),
     ],
     [


### PR DESCRIPTION
https://learn.microsoft.com/en-us/typography/opentype/spec/os2#ulunicoderange

## Description

Not sure if this is a typo error, or research thing. I did see some sources online claiming this block starts at 0xFF000, but the Microsoft spec definitely says 0xF0000

Not sure what other checks/utils use this data, but I've written the changelog entry for the one I know about

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

