### PR TITLE
Replace obsolete macos-13 with macos-latest in GH-Actions

### DIFF
--- a/.github/workflows/install_run.yml
+++ b/.github/workflows/install_run.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         profile:
           - description: Universal profile on a static font
             name: universal

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/tests/test_checks_glyf.py
+++ b/tests/test_checks_glyf.py
@@ -18,6 +18,8 @@ def test_check_nested_components(check):
 
     # We need to create a nested component. "second" has components, so setting
     # one of "quotedbl"'s components to "second" should do it.
+    # pylint: disable=[E1136]  # false positive
     ttFont["glyf"]["quotedbl"].components[0].glyphName = "second"
+    # pylint: enable=[E1136]
 
     assert_results_contain(check(ttFont), FAIL, "found-nested-components")

--- a/tests/test_checks_opentype_glyf.py
+++ b/tests/test_checks_opentype_glyf.py
@@ -59,8 +59,10 @@ def test_check_glyf_non_transformed_duplicate_components(check):
     assert_PASS(check(ttFont))
 
     # Set qutodbl's components to have the same x,y values
+    # pylint: disable=[E1136]  # false positive
     ttFont["glyf"]["quotedbl"].components[0].x = 0
     ttFont["glyf"]["quotedbl"].components[1].x = 0
     ttFont["glyf"]["quotedbl"].components[0].y = 0
     ttFont["glyf"]["quotedbl"].components[1].y = 0
+    # pylint: enable=[E1136]
     assert_results_contain(check(ttFont), FAIL, "found-duplicates")

--- a/tests/test_checks_opentype_post.py
+++ b/tests/test_checks_opentype_post.py
@@ -194,10 +194,12 @@ def test_check_italic_angle(check):
 
     ttFont = TTFont(TEST_FILE("cairo/CairoPlay-Italic.rightslanted.ttf"))
     assert_PASS(check(MockFont(ttFont=ttFont, style="Italic")))
+    # pylint: disable=[E1136]  # false positive
     ttFont["glyf"]["I"].endPtsOfContours = []
     ttFont["glyf"]["I"].coordinates = []
     ttFont["glyf"]["I"].flags = []
     ttFont["glyf"]["I"].numberOfContours = 0
+    # pylint: enable=[E1136]
     assert_results_contain(
         check(MockFont(ttFont=ttFont, style="Italic")), WARN, "empty-glyphs"
     )


### PR DESCRIPTION
## Description
`macos-13` runner is obsolete and must be replaced with `macos-14`, `macos-15`, or `macos-latest` so that GH-Actions can run.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

