### PR TITLE
Fix `UnboundLocalError` in Markdown report when all checks pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ A more detailed list of changes is available in the corresponding milestones for
 
 ## Upcoming release v1.1.1 (2025-Oct-?)
 
+### Bugfixes
+  - Fix an issue where Markdown reports throw an error when all checks pass (PR #5059)
+
 ### Changes to existing checks
 #### On the OpenType profile
   - **[opentype/monospace]**: Ensure check works with monospace OTF fonts (PR #5051)

--- a/Lib/fontbakery/reporters/ghmarkdown.py
+++ b/Lib/fontbakery/reporters/ghmarkdown.py
@@ -19,6 +19,7 @@ class GHMarkdownReporter(HTMLReporter):
         fatal_checks = {}
         experimental_checks = {}
         other_checks = {}
+        deprecation_warning = None
 
         num_checks = 0
         for section in data["sections"]:
@@ -77,7 +78,7 @@ class GHMarkdownReporter(HTMLReporter):
                             other_checks[key] = []
                         other_checks[key].append(check)
 
-                    if self.legacy_checkid_references:
+                    if deprecation_warning is None and self.legacy_checkid_references:
                         references = "\n - ".join(self.legacy_checkid_references)
                         deprecation_warning = (
                             "By late-December 2024, FontBakery version 0.13.0"
@@ -97,8 +98,6 @@ class GHMarkdownReporter(HTMLReporter):
                             f" - {references}\n"
                             "\n"
                         )
-                    else:
-                        deprecation_warning = None
 
         # Sort them by log-level results:
         ordering = ["ERROR", "FATAL", "FAIL", "WARN", "INFO", "PASS", "SKIP"]


### PR DESCRIPTION
## Description
A super simple fix, to ensure the variable `deprecation_warning` is instantiated in all situations, to prevent an `UnboundLocalError`.

I've also taken the opportunity to only set the `deprecation_warning` once, as it was being set inside a `for` loop and could be set multiple times to the same exact value.

Fixes #5058.
Fixes #5053.

## Checklist
- [x] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

